### PR TITLE
Data model update.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.idea/workspace.xml

--- a/opencdms/adapters/opencdmsdb/__init__.py
+++ b/opencdms/adapters/opencdmsdb/__init__.py
@@ -22,6 +22,7 @@
 # SOFTWARE.
 # =============================================================================
 from geoalchemy2 import Geography
+from sqlalchemy_json import mutable_json_type
 from sqlalchemy import (
     Column,
     DateTime,
@@ -41,13 +42,69 @@ from opencdms.models import cdm
 mapper_registry = registry()
 
 
+user = Table(
+    "user",
+    mapper_registry.metadata,
+    Column("id", String, comment="ID / primary key", primary_key=True, index=False),
+    Column("name", String, comment="Name of user/agent", index=False),
+    Column("description", String, comment="Description of user / agent", index=False),
+    schema="cdm"
+)
+
+
+status = Table(
+    "status",
+    mapper_registry.metadata,
+    Column("id", String, comment="ID / primary key", primary_key=True, index=False),
+    Column("name", String, comment="Short name for status", index=False),
+    Column("description", String, comment="Description of the status", index=False),
+    schema="cdm"
+)
+
+
+responsible_party = Table(
+    "responsible_party",
+    mapper_registry.metadata,
+    Column("id", String, comment="A value uniquely identifying a party (individual or organization).", primary_key=True, index=False),
+    Column("name", String, comment="The name of the organization or the individual.", index=False),
+    Column("position_name", String, comment="Role or position of the responsible person.", index=False),
+    Column("organization", String, comment="Organization/affiliation of the individual/responsible person. In case of an organization, the name property should be used and this property is not to be used.", index=False),
+    Column("logo", mutable_json_type(dbtype=JSONB, nested=True), comment="Graphic identifying a party", index=False),
+    Column("contact_information", mutable_json_type(dbtype=JSONB, nested=True), comment="Contact information", index=False),
+    schema="cdm"
+)
+
+
 observation_type = Table(
     "observation_type",
     mapper_registry.metadata,
-    Column("id", Integer, comment="ID / primary key", primary_key=True, index=False),
+    Column("id", String, comment="ID / primary key", primary_key=True, index=False),
+    Column("authority", String, comment="naming authority for code list entry", index=False),
     Column("name", String, comment="Short name for observation type", index=False),
     Column("description", String, comment="Description of observation type", index=False),
-    Column("links", JSONB, comment="Link(s) to definition of observation type", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Link(s) to definition of observation type", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+facility_type = Table(
+    "facility_type",
+    mapper_registry.metadata,
+    Column("id", String, comment="ID / primary key", primary_key=True, index=False),
+    Column("authority", String, comment="Naming authority for code list entry", index=False),
+    Column("name", String, comment="Short name for feature type", index=False),
+    Column("description", String, comment="Description of feature type", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Link(s) to definition of feature type", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
     schema="cdm"
 )
 
@@ -55,19 +112,50 @@ observation_type = Table(
 feature_type = Table(
     "feature_type",
     mapper_registry.metadata,
-    Column("id", Integer, comment="ID / primary key", primary_key=True, index=False),
+    Column("id", String, comment="ID / primary key", primary_key=True, index=False),
+    Column("authority", String, comment="Naming authority for code list entry", index=False),
     Column("name", String, comment="Short name for feature type", index=False),
     Column("description", String, comment="Description of feature type", index=False),
-    Column("links", JSONB, comment="Link(s) to definition of feature type", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Link(s) to definition of feature type", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
     schema="cdm"
 )
 
 
-user = Table(
-    "user",
+wmo_region = Table(
+    "wmo_region",
     mapper_registry.metadata,
     Column("id", String, comment="ID / primary key", primary_key=True, index=False),
-    Column("name", String, comment="Name of user", index=False),
+    Column("name", String, comment="Short name for WMO region", index=False),
+    Column("description", String, comment="Long name of WMO region", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Link(s) to definition of feature type", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+territory = Table(
+    "territory",
+    mapper_registry.metadata,
+    Column("id", String, comment="ID / primary key", primary_key=True, index=False),
+    Column("ISO3c", String, comment="ISO 3 character country code", index=False),
+    Column("name", String, comment="Short name for feature type", index=False),
+    Column("description", String, comment="Description of feature type", index=False),
+    Column("wmo_region_id",ForeignKey("cdm.wmo_region.id"), comment="WMO region that represents the territory", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Link(s) to definition of feature type", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
     schema="cdm"
 )
 
@@ -75,12 +163,18 @@ user = Table(
 observed_property = Table(
     "observed_property",
     mapper_registry.metadata,
-    Column("id", Integer, comment="ID / primary key", primary_key=True, index=False),
-    Column("short_name", String, comment="Short name representation of observed property, e.g. 'at'", index=False),
+    Column("id", String, comment="ID / primary key", primary_key=True, index=False),
+    Column("authority", String, comment="Naming authority for code list entry", index=False),
+    Column("short_name", String, comment="Short name representation of observed property, e.g. 'at' for air temperature", index=False),
     Column("standard_name", String, comment="CF standard name (if applicable), e.g. 'air_temperature'", index=False),
     Column("units", String, comment="Canonical units, e.g. 'Kelvin'", index=False),
     Column("description", String, comment="Description of observed property", index=False),
-    Column("links", JSONB, comment="Link(s) to definition / source of observed property", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Link(s) to definition / source of observed property", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
     schema="cdm"
 )
 
@@ -88,20 +182,16 @@ observed_property = Table(
 observing_procedure = Table(
     "observing_procedure",
     mapper_registry.metadata,
-    Column("id", Integer, comment="ID / primary key", primary_key=True, index=False),
+    Column("id", String, comment="ID / primary key", primary_key=True, index=False),
+    Column("authority", String, comment="Naming authority for code list entry", index=False),
     Column("name", String, comment="Name of observing procedure", index=False),
     Column("description", String, comment="Description of observing procedure", index=False),
-    Column("links", JSONB, comment="Link(s) to further information", index=False),
-    schema="cdm"
-)
-
-
-record_status = Table(
-    "record_status",
-    mapper_registry.metadata,
-    Column("id", Integer, comment="ID / primary key", primary_key=True, index=False),
-    Column("name", String, comment="Short name for status", index=False),
-    Column("description", String, comment="Description of the status", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Link(s) to further information", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
     schema="cdm"
 )
 
@@ -109,10 +199,212 @@ record_status = Table(
 time_zone = Table(
     "time_zone",
     mapper_registry.metadata,
-    Column("id", Integer, comment="ID / primary key", primary_key=True, index=False),
+    Column("id", String, comment="ID / primary key", primary_key=True, index=False),
     Column("abbreviation", String, comment="Abbreviation for time zone", index=False),
     Column("name", String, comment="Name / description of timezone", index=False),
-    Column("offset", String, comment="Offset from UTC", index=False),
+    Column("offset", Numeric, comment="Offset from UTC (hours)", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+source_type = Table(
+    "source_type",
+    mapper_registry.metadata,
+    Column("id", String, comment="ID / primary key", primary_key=True, index=False),
+    Column("name", String, comment="Name of source type", index=False),
+    Column("description", String, comment="Description of source type, e.g. file etc", index=False),
+    Column("scheme", String, comment="IANA scheme (if applicable)", index=False),
+    Column("links", String, comment="Links providing further definition of source type", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+media_type = Table(
+    "media_type",
+    mapper_registry.metadata,
+    Column("id", String, comment="", primary_key=True, index=False),
+    Column("name", String, comment="", index=False),
+    Column("description", String, comment="Type of media uploaded", index=False),
+    schema="cdm"
+)
+
+
+climate_zone = Table(
+    "climate_zone",
+    mapper_registry.metadata,
+    Column("id", String, comment="", primary_key=True, index=False),
+    Column("authority", String, comment="Naming authority for code list entry", index=False),
+    Column("name", String, comment="", index=False),
+    Column("description", String, comment="", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Links providing further definition of climate zone", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+surface_cover = Table(
+    "surface_cover",
+    mapper_registry.metadata,
+    Column("id", String, comment="", primary_key=True, index=False),
+    Column("authority", String, comment="Naming authority for code list entry", index=False),
+    Column("name", String, comment="", index=False),
+    Column("description", String, comment="", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Links providing further definition of climate zone", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+surface_roughness = Table(
+    "surface_roughness",
+    mapper_registry.metadata,
+    Column("id", String, comment="", primary_key=True, index=False),
+    Column("authority", String, comment="Naming authority for code list entry", index=False),
+    Column("name", String, comment="", index=False),
+    Column("description", String, comment="", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Links providing further definition of climate zone", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+topography = Table(
+    "topography",
+    mapper_registry.metadata,
+    Column("id", String, comment="", primary_key=True, index=False),
+    Column("authority", String, comment="Naming authority for code list entry", index=False),
+    Column("name", String, comment="", index=False),
+    Column("description", String, comment="", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Links providing further definition of climate zone", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+season = Table(
+    "season",
+    mapper_registry.metadata,
+    Column("id", String, comment="", primary_key=True, index=False),
+    Column("name", String, comment="", index=False),
+    Column("description", String, comment="", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Links providing further definition of climate zone", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+programme = Table(
+    "programme",
+    mapper_registry.metadata,
+    Column("id", String, comment="", primary_key=True, index=False),
+    Column("authority", String, comment="Naming authority for code list entry", index=False),
+    Column("name", String, comment="", index=False),
+    Column("description", String, comment="", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Links providing further definition of climate zone", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+observing_method = Table(
+    "observing_method",
+    mapper_registry.metadata,
+    Column("id", String, comment="", primary_key=True, index=False),
+    Column("authority", String, comment="Naming authority for code list entry", index=False),
+    Column("name", String, comment="", index=False),
+    Column("description", String, comment="Description of observing method", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Links providing further definition of observing method", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+exposure = Table(
+    "exposure",
+    mapper_registry.metadata,
+    Column("id", String, comment="", primary_key=True, index=False),
+    Column("name", String, comment="", index=False),
+    Column("description", String, comment="Description of sensor exposure according to WMO-No. 8", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Links providing further definition of exposure class", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+reference_surface = Table(
+    "reference_surface",
+    mapper_registry.metadata,
+    Column("id", String, comment="", primary_key=True, index=False),
+    Column("name", String, comment="", index=False),
+    Column("description", String, comment="Description of reference surface", index=False),
+    schema="cdm"
+)
+
+
+role = Table(
+    "role",
+    mapper_registry.metadata,
+    Column("id", String, comment="Primary key for this record", primary_key=True, index=False),
+    Column("authority", String, comment="Namelist authority", index=False),
+    Column("name", String, comment="The name of the role", index=False),
+    Column("description", String, comment="Description of the role", index=False),
+    schema="cdm"
+)
+
+
+media = Table(
+    "media",
+    mapper_registry.metadata,
+    Column("id", String, comment="", primary_key=True, index=False),
+    Column("media_type_id",ForeignKey("cdm.media_type.id"), comment="", index=False),
+    Column("description", String, comment="", index=False),
+    Column("created", DateTime(timezone=True), comment="", index=False),
+    Column("creator", String, comment="", index=False),
+    Column("rights", Integer, comment="", index=False),
+    Column("source", String, comment="", index=False),
+    Column("data", mutable_json_type(dbtype=JSONB, nested=True), comment="", index=False),
     schema="cdm"
 )
 
@@ -123,23 +415,114 @@ host = Table(
     Column("id", String, comment="ID / primary key", primary_key=True, index=False),
     Column("name", String, comment="Preferred name of host", index=False),
     Column("description", String, comment="Description of host", index=False),
-    Column("links", JSONB, comment="URI to host, e.g. to OSCAR/Surface", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="URI to host, e.g. to OSCAR/Surface", index=False),
     Column("location", Geography, comment="Location of station", index=False),
-    Column("elevation", Numeric, comment="Elevation of station above mean sea level", index=False),
+    Column("elevation", Numeric, comment="Elevation of station above mean sea level in meters", index=False),
     Column("wigos_station_identifier", String, comment="WIGOS station identifier", index=False),
-    Column("facility_type", String, comment="Type of observing facility, fixed land, mobile sea, etc", index=False),
+    Column("facility_type_id",ForeignKey("cdm.facility_type.id"), comment="Type of observing facility, fixed land, mobile sea, etc", index=False),
     Column("date_established", DateTime(timezone=True), comment="Date host was first established", index=False),
     Column("date_closed", DateTime(timezone=True), comment="Date host was first established", index=False),
-    Column("wmo_region", String, comment="WMO region in which the host is located", index=False),
-    Column("territory", String, comment="Territory the host is located in", index=False),
+    Column("wmo_region_id",ForeignKey("cdm.wmo_region.id"), comment="WMO region in which the host is located", index=False),
+    Column("territory_id",ForeignKey("cdm.territory.id"), comment="Territory the host is located in", index=False),
+    Column("time_zone_id",ForeignKey("cdm.time_zone.id"), comment="Time zone the host is located in", index=False),
     Column("valid_from", DateTime(timezone=True), comment="Date from which the details for this record are valid", index=False),
     Column("valid_to", DateTime(timezone=True), comment="Date after which the details for this record are no longer valid", index=False),
-    Column("version", Integer, comment="Version number of this record", index=False),
-    Column("change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
-    Column("user_id",ForeignKey("cdm.user.id"), comment="Which user last modified this record", index=False),
-    Column("status_id",ForeignKey("cdm.record_status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
     Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
-    Column("time_zone_id",ForeignKey("cdm.time_zone.id"), comment="Time zone the host is located in", index=False),
+    schema="cdm"
+)
+
+
+host_environment = Table(
+    "host_environment",
+    mapper_registry.metadata,
+    Column("id", String, comment="Primary key for this record", primary_key=True, index=False),
+    Column("host", String, comment="Host associated with this record", index=False),
+    Column("climate_zone_id",ForeignKey("cdm.climate_zone.id"), comment="Climate zone that the associated host is located in", index=False),
+    Column("surface_cover_id",ForeignKey("cdm.surface_cover.id"), comment="Type of sueface cover", index=False),
+    Column("surface_roughness_id",ForeignKey("cdm.surface_roughness.id"), comment="Typical surface roughness of the site surrounding the host", index=False),
+    Column("topography_id",ForeignKey("cdm.topography.id"), comment="Topography of the environment surrounding the host", index=False),
+    Column("season_id",ForeignKey("cdm.season.id"), comment="Season that is applicable to this record (e.g. all, winter, spring, summer, autumn)", index=False),
+    Column("valid_from", DateTime(timezone=True), comment="Date the this record is valid from", index=False),
+    Column("valid_to", DateTime(timezone=True), comment="date that this record is valid to", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+host_affiliation = Table(
+    "host_affiliation",
+    mapper_registry.metadata,
+    Column("id", String, comment="Primary key for this record", primary_key=True, index=False),
+    Column("host_id",ForeignKey("cdm.host.id"), comment="Host described by this record", index=False),
+    Column("programme_id",ForeignKey("cdm.programme.id"), comment="Observing programme that this host is affiliated with", index=False),
+    Column("valid_from", DateTime(timezone=True), comment="Date from which the details for this record are valid", index=False),
+    Column("valid_to", DateTime(timezone=True), comment="Date after which the details for this record are no longer valid", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+host_alias = Table(
+    "host_alias",
+    mapper_registry.metadata,
+    Column("id", String, comment="Primary key for this record", primary_key=True, index=False),
+    Column("host_id",ForeignKey("cdm.host.id"), comment="Primary ID by which the host is known", index=False),
+    Column("alternative", String, comment="Alternative ID by which the host is known", index=False),
+    Column("alternative_name", String, comment="Alternative name by which the host is known", index=False),
+    Column("valid_from", DateTime(timezone=True), comment="Date the alternative id/name was used from", index=False),
+    Column("valid_to", DateTime(timezone=True), comment="Date the alternative id/name was used to", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+host_responsible_party = Table(
+    "host_responsible_party",
+    mapper_registry.metadata,
+    Column("id", String, comment="Unique identifier for this record", primary_key=True, index=False),
+    Column("responsible_party_id",ForeignKey("cdm.responsible_party.id"), comment="The responsible party", index=False),
+    Column("role_id",ForeignKey("cdm.role.id"), comment="The role this responsible party plays", index=False),
+    Column("host_id",ForeignKey("cdm.host.id"), comment="The host that this record corresponds to", index=False),
+    Column("valid_from", DateTime(timezone=True), comment="Date this record is valid from", index=False),
+    Column("valid_to", DateTime(timezone=True), comment="Date this record is valid to", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+host_media = Table(
+    "host_media",
+    mapper_registry.metadata,
+    Column("id", String, comment="Primary key for this record", primary_key=True, index=False),
+    Column("host_id",ForeignKey("cdm.host.id"), comment="", index=False),
+    Column("media_id",ForeignKey("cdm.media.id"), comment="", index=False),
+    Column("valid_from", DateTime(timezone=True), comment="", index=False),
+    Column("valid_to", DateTime(timezone=True), comment="", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
     schema="cdm"
 )
 
@@ -150,15 +533,89 @@ observer = Table(
     Column("id", String, comment="ID / primary key", primary_key=True, index=False),
     Column("name", String, comment="Name of sensor", index=False),
     Column("description", String, comment="Description of sensor", index=False),
-    Column("links", JSONB, comment="Link(s) to further information", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Link(s) to further information", index=False),
     Column("location", Geography, comment="Location of observer", index=False),
     Column("elevation", Numeric, comment="Elevation of observer above mean sea level", index=False),
     Column("manufacturer", String, comment="Make, or manufacturer, of sensor", index=False),
     Column("model", String, comment="Model of sensor", index=False),
     Column("serial_number", String, comment="Serial number of sensor", index=False),
     Column("firmware_version", String, comment="Firmware version of software installed in sensor", index=False),
-    Column("uncertainty", String, comment="Standard uncertainty in measurements from sensor", index=False),
-    Column("observing_method", String, comment="Primary method/principles by which the sensor makes measurements", index=False),
+    Column("control_schedule_id",ForeignKey("cdm.control_schedule.id"), comment="Link to information on calibration schedule and details", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+control_schedule = Table(
+    "control_schedule",
+    mapper_registry.metadata,
+    Column("id", String, comment="", primary_key=True, index=False),
+    Column("name", String, comment="", index=False),
+    Column("description", String, comment="Description of control schedule", index=False),
+    schema="cdm"
+)
+
+
+observer_characteristics = Table(
+    "observer_characteristics",
+    mapper_registry.metadata,
+    Column("id", String, comment="Primary key for this record", primary_key=True, index=False),
+    Column("observer_id",ForeignKey("cdm.observer.id"), comment="The observer to which this record applies", index=False),
+    Column("observed_property_id",ForeignKey("cdm.observed_property.id"), comment="The observed parameter to which this record applies", index=False),
+    Column("observing_method_id",ForeignKey("cdm.observing_method.id"), comment="Primary method/principles by which the sensor makes measurements", index=False),
+    Column("measurement_units", Integer, comment="The units used in this record", index=False),
+    Column("drift_per_unit_time", Numeric, comment="Sensor drift per unit time, units specified by measurement units, unit time by unit time", index=False),
+    Column("unit_time", Integer, comment="Unit time for drift per unit time (seconds)", index=False),
+    Column("valid_min", Numeric, comment="Minimum observable value by sensor, in units specificed by measurement units", index=False),
+    Column("valid_max", Numeric, comment="Maximum observable value by sensor, in units specificed by measurement units", index=False),
+    Column("measurement_uncertainty", Numeric, comment="Measurement uncertainty for measurements from this sensor, 2 sigma. Units as per measuremenet units", index=False),
+    Column("measurement_accuracy", Numeric, comment="Measurement accuracy (trueness) for measurements from this sensor, 2 sigma. Units as per measuremenet units", index=False),
+    Column("measurement_repeatability", Numeric, comment="Measurement repeatability (precision) for measurements from this sensor, 2 sigma. Units as per measuremenet units", index=False),
+    Column("measurement_resolution", Numeric, comment="Minimum change detectable for measurements from this sensor. Units as per measurement units", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+observer_responsible_party = Table(
+    "observer_responsible_party",
+    mapper_registry.metadata,
+    Column("id", String, comment="", primary_key=True, index=False),
+    Column("responsible_party_id",ForeignKey("cdm.responsible_party.id"), comment="", index=False),
+    Column("role_id",ForeignKey("cdm.role.id"), comment="", index=False),
+    Column("observer_id",ForeignKey("cdm.observer.id"), comment="The observer that this record corresponds to", index=False),
+    Column("valid_from", DateTime(timezone=True), comment="Date this record is valid from", index=False),
+    Column("valid_to", DateTime(timezone=True), comment="Date this record is valid to", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+observer_media = Table(
+    "observer_media",
+    mapper_registry.metadata,
+    Column("id", String, comment="Primary key for this record", primary_key=True, index=False),
+    Column("observer_id",ForeignKey("cdm.observer.id"), comment="", index=False),
+    Column("media_id",ForeignKey("cdm.media.id"), comment="", index=False),
+    Column("valid_from", DateTime(timezone=True), comment="", index=False),
+    Column("valid_to", DateTime(timezone=True), comment="", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
     schema="cdm"
 )
 
@@ -168,7 +625,12 @@ collection = Table(
     mapper_registry.metadata,
     Column("id", String, comment="ID / primary key", primary_key=True, index=False),
     Column("name", String, comment="Name of collection", index=False),
-    Column("links", JSONB, comment="Link(s) to further information on collection", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Link(s) to further information on collection", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
     schema="cdm"
 )
 
@@ -177,22 +639,19 @@ feature = Table(
     "feature",
     mapper_registry.metadata,
     Column("id", String, comment="ID / primary key", primary_key=True, index=False),
-    Column("type_id",ForeignKey("cdm.feature_type.id"), comment="enumerated feature type", index=False),
-    Column("geometry", Geography, comment="", index=False),
-    Column("elevation", Numeric, comment="Elevation of feature above mean sea level", index=False),
-    Column("parent_id",ForeignKey("cdm.feature.id"), comment="Parent feature for this feature if nested", index=False),
     Column("name", String, comment="Name of feature", index=False),
     Column("description", String, comment="Description of feature", index=False),
-    Column("links", JSONB, comment="Link(s) to further information on feature", index=False),
-    schema="cdm"
-)
-
-
-source_type = Table(
-    "source_type",
-    mapper_registry.metadata,
-    Column("id", String, comment="ID / primary key", primary_key=True, index=False),
-    Column("description", String, comment="Description of source type, e.g. file etc", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Link(s) to further information on feature", index=False),
+    Column("feature_type_id",ForeignKey("cdm.feature_type.id"), comment="enumerated feature type", index=False),
+    Column("geometry", Geography, comment="", index=False),
+    Column("elevation", Numeric, comment="Meam elevation of feature above mean sea level", index=False),
+    Column("parent_id",ForeignKey("cdm.feature.id"), comment="Parent feature for this feature if nested", index=False),
+    Column("properties", mutable_json_type(dbtype=JSONB, nested=True), comment="Array of named values consistent with that defined for the feature type", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
     schema="cdm"
 )
 
@@ -201,10 +660,16 @@ source = Table(
     "source",
     mapper_registry.metadata,
     Column("id", String, comment="ID / primary key", primary_key=True, index=False),
-    Column("source_type_id",ForeignKey("cdm.source_type.id"), comment="The type of source", index=False),
     Column("name", String, comment="Name of source", index=False),
-    Column("links", JSONB, comment="Link(s) to further information on source", index=False),
+    Column("description", String, comment="Description of source type, e.g. file etc", index=False),
+    Column("source_type_id",ForeignKey("cdm.source_type.id"), comment="The type of source", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="Link(s) to further information on source", index=False),
     Column("processor", String, comment="Name of processor used to ingest the data", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
     schema="cdm"
 )
 
@@ -214,14 +679,14 @@ observation = Table(
     mapper_registry.metadata,
     Column("id", String, comment="ID / primary key", primary_key=True, index=False),
     Column("location", Geography, comment="Location of observation", index=True),
-    Column("elevation", Numeric, comment="Elevation of observation above mean sea level", index=False),
+    Column("elevation", Numeric, comment="Elevation of observation above mean sea level (in meters)", index=False),
     Column("observation_type_id",ForeignKey("cdm.observation_type.id"), comment="Type of observation", index=True),
     Column("phenomenon_start", DateTime(timezone=True), comment="Start time of the phenomenon being observed or observing period, if missing assumed instantaneous with time given by phenomenon_end", index=False),
     Column("phenomenon_end", DateTime(timezone=True), comment="End time of the phenomenon being observed or observing period", index=True),
     Column("result_value", Numeric, comment="The value of the result in float representation", index=False),
     Column("result_uom", String, comment="Units used to represent the value being observed", index=False),
     Column("result_description", String, comment="str representation of the result if applicable", index=False),
-    Column("result_quality", JSONB, comment="JSON representation of the result quality, key / value pairs", index=False),
+    Column("result_quality", mutable_json_type(dbtype=JSONB, nested=True), comment="JSON representation of the result quality, key / value pairs", index=False),
     Column("result_time", DateTime(timezone=True), comment="Time that the result became available", index=False),
     Column("valid_from", DateTime(timezone=True), comment="Time that the result starts to be valid", index=False),
     Column("valid_to", DateTime(timezone=True), comment="Time after which the result is no longer valid", index=False),
@@ -229,33 +694,134 @@ observation = Table(
     Column("observer_id",ForeignKey("cdm.observer.id"), comment="Observer associated with making the observation, equivalent to OGC OMS 'observer'", index=False),
     Column("observed_property_id",ForeignKey("cdm.observed_property.id"), comment="The phenomenon, or thing, being observed", index=True),
     Column("observing_procedure_id",ForeignKey("cdm.observing_procedure.id"), comment="Procedure used to make the observation", index=False),
-    Column("report_id", String, comment="Parent report ID, used to link coincident observations together", index=False),
-    Column("collection_id",ForeignKey("cdm.collection.id"), comment="Primary collection or dataset that this observation belongs to", index=True),
-    Column("parameter", JSONB, comment="List of key/ value pairs in dict", index=False),
-    Column("feature_of_interest_id",ForeignKey("cdm.feature.id"), comment="Feature that this observation is associated with", index=False),
-    Column("version", Integer, comment="Version number of this record", index=False),
-    Column("change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
-    Column("user_id",ForeignKey("cdm.user.id"), comment="Which user last modified this record", index=False),
-    Column("status_id",ForeignKey("cdm.record_status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("collection_id",ForeignKey("cdm.collection.id"), comment="Primary collection or dataset that this observation belongs to. Note: this is different to the OGC OMS collection concept.", index=True),
+    Column("parameter", mutable_json_type(dbtype=JSONB, nested=True), comment="List of key/ value pairs in dict", index=False),
+    Column("feature_id",ForeignKey("cdm.feature.id"), comment="Feature of interest that this observation is associated with", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
     Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
-    Column("source_id",ForeignKey("cdm.source.id"), comment="The source of this record", index=True),
+    Column("_source_id",ForeignKey("cdm.source.id"), comment="The source of this record", index=True),
+    Column("_source_identifier", String, comment="The original identifier for the record from the data source", index=True),
+    schema="cdm"
+)
+
+
+deployment = Table(
+    "deployment",
+    mapper_registry.metadata,
+    Column("id", String, comment="Unique ID / primary key for deployment", primary_key=True, index=False),
+    Column("host_id",ForeignKey("cdm.host.id"), comment="", index=False),
+    Column("observer_id",ForeignKey("cdm.observer.id"), comment="", index=False),
+    Column("valid_from", DateTime(timezone=True), comment="", index=False),
+    Column("valid_to", DateTime(timezone=True), comment="", index=False),
+    Column("installation_height", Numeric, comment="Installation height above reference surface (in meters)", index=False),
+    Column("reference_surface_id",ForeignKey("cdm.reference_surface.id"), comment="", index=False),
+    Column("exposure_id",ForeignKey("cdm.exposure.id"), comment="", index=False),
+    Column("configuration", String, comment="Textual description of sensor installation and configuration", index=False),
+    Column("maintenance_schedule_id",ForeignKey("cdm.maintenance_schedule.id"), comment="", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+maintenance_schedule = Table(
+    "maintenance_schedule",
+    mapper_registry.metadata,
+    Column("id", String, comment="", primary_key=True, index=False),
+    Column("name", String, comment="", index=False),
+    Column("description", String, comment="Description of maintenance schedule", index=False),
+    schema="cdm"
+)
+
+
+deployment_media = Table(
+    "deployment_media",
+    mapper_registry.metadata,
+    Column("id", String, comment="Primary key for this record", primary_key=True, index=False),
+    Column("deployment_id",ForeignKey("cdm.deployment.id"), comment="", index=False),
+    Column("media_id",ForeignKey("cdm.media.id"), comment="", index=False),
+    Column("valid_from", DateTime(timezone=True), comment="", index=False),
+    Column("valid_to", DateTime(timezone=True), comment="", index=False),
+    Column("_version", Integer, comment="Version number of this record", index=False),
+    Column("_change_date", DateTime(timezone=True), comment="Date this record was changed", index=False),
+    Column("_user_id",ForeignKey("cdm.user.id"), comment="Which user/agent last modified this record", index=False),
+    Column("_status_id",ForeignKey("cdm.status.id"), comment="Whether this is the latest version or an archived version of the record", index=False),
+    Column("comments", String, comment="Free text comments on this record, for example description of changes made etc", index=False),
+    schema="cdm"
+)
+
+
+record = Table(
+    "record",
+    mapper_registry.metadata,
+    Column("id", String, comment="A unique identifier of the catalogue record.", primary_key=True, index=False),
+    Column("time", String, comment="The temporal extent of the resource. Can be null if there is no associated temporal extent.", index=False),
+    Column("title", String, comment="A human-readable name given to the resource.", index=False),
+    Column("location", Geography, comment="A geometry associated with the resource that is used for discovery. Can be null if there is no associated geometry.", index=False),
+    Column("created", String, comment="Date of creation of this record.", index=False),
+    Column("updated", String, comment="The most recent date on which the record was changed.", index=False),
+    Column("resource_type", String, comment="The nature or genre of the resource. The value should be a code, convenient for filtering records. Where available, a link to the canonical URI of the record type resource will be added to the 'links' property.", index=False),
+    Column("description", String, comment="A free-text account of the resource.", index=False),
+    Column("keywords", String, comment="The topic or topics of the resource. Typically represented using free-form keywords, tags, key phrases, or classification codes. Semi-colon delimited", index=False),
+    Column("language", String, comment="The natural language used for textual values (e.g. titles, descriptions, etc.) of the resource. ISO 639-1/639-2 codes should be used.", index=False),
+    Column("external_ids", mutable_json_type(dbtype=JSONB, nested=True), comment="An identifier for the resource assigned by an external (to the catalogue) entity.", index=False),
+    Column("themes", mutable_json_type(dbtype=JSONB, nested=True), comment="A knowledge organization system used to classify the resource.", index=False),
+    Column("formats", mutable_json_type(dbtype=JSONB, nested=True), comment="A list of available distributions of the resource.", index=False),
+    Column("providers", mutable_json_type(dbtype=JSONB, nested=True), comment="A list of providers qualified by their role in association to the record.", index=False),
+    Column("license", String, comment="A legal document under which the resource is made available. The value should be a code, convenient for filtering the records. Where applicable, the use of the identifiers from the SPDX License List is recommended. If multiple licenses apply, it is recommended to use ''various'.  Where available, links to a URI of each applicable license should be added to the 'links' property.", index=False),
+    Column("rights", String, comment="A statement that concerns all rights not addressed by the license such as a copyright statement.", index=False),
+    Column("links", mutable_json_type(dbtype=JSONB, nested=True), comment="A list of links for accessing the resource (e.g. download link, access link) in one of the supported distribution formats and/or links to other resources associated with this resource. Also, a list of links for navigating the API (e.g. prev, next, etc.).  Since the specification requires that at least the self link be present then the min items for this list should be one.", index=False),
     schema="cdm"
 )
 
 
 def start_mappers():
-    mapper_registry.map_imperatively(cdm.ObservationType, observation_type)
-    mapper_registry.map_imperatively(cdm.FeatureType, feature_type)
     mapper_registry.map_imperatively(cdm.User, user)
+    mapper_registry.map_imperatively(cdm.Status, status)
+    mapper_registry.map_imperatively(cdm.ResponsibleParty, responsible_party)
+    mapper_registry.map_imperatively(cdm.ObservationType, observation_type)
+    mapper_registry.map_imperatively(cdm.FacilityType, facility_type)
+    mapper_registry.map_imperatively(cdm.FeatureType, feature_type)
+    mapper_registry.map_imperatively(cdm.WmoRegion, wmo_region)
+    mapper_registry.map_imperatively(cdm.Territory, territory)
     mapper_registry.map_imperatively(cdm.ObservedProperty, observed_property)
     mapper_registry.map_imperatively(cdm.ObservingProcedure, observing_procedure)
-    mapper_registry.map_imperatively(cdm.RecordStatus, record_status)
     mapper_registry.map_imperatively(cdm.TimeZone, time_zone)
+    mapper_registry.map_imperatively(cdm.SourceType, source_type)
+    mapper_registry.map_imperatively(cdm.MediaType, media_type)
+    mapper_registry.map_imperatively(cdm.ClimateZone, climate_zone)
+    mapper_registry.map_imperatively(cdm.SurfaceCover, surface_cover)
+    mapper_registry.map_imperatively(cdm.SurfaceRoughness, surface_roughness)
+    mapper_registry.map_imperatively(cdm.Topography, topography)
+    mapper_registry.map_imperatively(cdm.Season, season)
+    mapper_registry.map_imperatively(cdm.Programme, programme)
+    mapper_registry.map_imperatively(cdm.ObservingMethod, observing_method)
+    mapper_registry.map_imperatively(cdm.Exposure, exposure)
+    mapper_registry.map_imperatively(cdm.ReferenceSurface, reference_surface)
+    mapper_registry.map_imperatively(cdm.Role, role)
+    mapper_registry.map_imperatively(cdm.Media, media)
     mapper_registry.map_imperatively(cdm.Host, host)
+    mapper_registry.map_imperatively(cdm.HostEnvironment, host_environment)
+    mapper_registry.map_imperatively(cdm.HostAffiliation, host_affiliation)
+    mapper_registry.map_imperatively(cdm.HostAlias, host_alias)
+    mapper_registry.map_imperatively(cdm.HostResponsibleParty, host_responsible_party)
+    mapper_registry.map_imperatively(cdm.HostMedia, host_media)
     mapper_registry.map_imperatively(cdm.Observer, observer)
+    mapper_registry.map_imperatively(cdm.ControlSchedule, control_schedule)
+    mapper_registry.map_imperatively(cdm.ObserverCharacteristics, observer_characteristics)
+    mapper_registry.map_imperatively(cdm.ObserverResponsibleParty, observer_responsible_party)
+    mapper_registry.map_imperatively(cdm.ObserverMedia, observer_media)
     mapper_registry.map_imperatively(cdm.Collection, collection)
     mapper_registry.map_imperatively(cdm.Feature, feature)
-    mapper_registry.map_imperatively(cdm.SourceType, source_type)
     mapper_registry.map_imperatively(cdm.Source, source)
     mapper_registry.map_imperatively(cdm.Observation, observation)
-
+    mapper_registry.map_imperatively(cdm.Deployment, deployment)
+    mapper_registry.map_imperatively(cdm.MaintenanceSchedule, maintenance_schedule)
+    mapper_registry.map_imperatively(cdm.DeploymentMedia, deployment_media)
+    mapper_registry.map_imperatively(cdm.Record, record)

--- a/opencdms/models/cdm.py
+++ b/opencdms/models/cdm.py
@@ -43,83 +43,21 @@ class DomainModelBase(AbstractBase):
 
 
 @dataclass
-class ObservationType(DomainModelBase):
-    id: int
-    name: str
-    description: str
-    links: Optional[dict]
-    _comments = {
-        "id": "ID / primary key",
-        "name": "Short name for observation type",
-        "description": "Description of observation type",
-        "links": "Link(s) to definition of observation type"
-    }
-    _comment = "placeholder"
-
-
-@dataclass
-class FeatureType(DomainModelBase):
-    id: int
-    name: str
-    description: str
-    links: Optional[dict]
-    _comments = {
-        "id": "ID / primary key",
-        "name": "Short name for feature type",
-        "description": "Description of feature type",
-        "links": "Link(s) to definition of feature type"
-    }
-    _comment = "placeholder"
-
-
-@dataclass
 class User(DomainModelBase):
     id: str
     name: str
-    _comments = {
-        "id": "ID / primary key",
-        "name": "Name of user"
-    }
-    _comment = "placeholder"
-
-
-@dataclass
-class ObservedProperty(DomainModelBase):
-    id: int
-    short_name: str
-    standard_name: Optional[str]
-    units: str
     description: str
-    links: Optional[dict]
     _comments = {
         "id": "ID / primary key",
-        "short_name": "Short name representation of observed property, e.g. 'at'",
-        "standard_name": "CF standard name (if applicable), e.g. 'air_temperature'",
-        "units": "Canonical units, e.g. 'Kelvin'",
-        "description": "Description of observed property",
-        "links": "Link(s) to definition / source of observed property"
+        "name": "Name of user/agent",
+        "description": "Description of user / agent"
     }
     _comment = "placeholder"
 
 
 @dataclass
-class ObservingProcedure(DomainModelBase):
-    id: int
-    name: str
-    description: str
-    links: Optional[dict]
-    _comments = {
-        "id": "ID / primary key",
-        "name": "Name of observing procedure",
-        "description": "Description of observing procedure",
-        "links": "Link(s) to further information"
-    }
-    _comment = "placeholder"
-
-
-@dataclass
-class RecordStatus(DomainModelBase):
-    id: int
+class Status(DomainModelBase):
+    id: str
     name: str
     description: str
     _comments = {
@@ -131,18 +69,543 @@ class RecordStatus(DomainModelBase):
 
 
 @dataclass
+class ResponsibleParty(DomainModelBase):
+    id: str
+    name: str
+    position_name: Optional[str]
+    organization: Optional[str]
+    logo: Optional[dict]
+    contact_information: Optional[dict]
+    _comments = {
+        "id": "A value uniquely identifying a party (individual or organization).",
+        "name": "The name of the organization or the individual.",
+        "position_name": "Role or position of the responsible person.",
+        "organization": "Organization/affiliation of the individual/responsible person. In case of an organization, the name property should be used and this property is not to be used.",
+        "logo": "Graphic identifying a party",
+        "contact_information": "Contact information"
+    }
+    _comment = "Identification of, and means of communication with, person responsible for the resource. oarec party"
+
+
+@dataclass
+class ObservationType(DomainModelBase):
+    id: str
+    authority: str
+    name: str
+    description: str
+    links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "ID / primary key",
+        "authority": "naming authority for code list entry",
+        "name": "Short name for observation type",
+        "description": "Description of observation type",
+        "links": "Link(s) to definition of observation type",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "Table to store observation type, e.g. hourly weather report, raw data, etc"
+
+
+@dataclass
+class FacilityType(DomainModelBase):
+    id: str
+    authority: str
+    name: str
+    description: str
+    links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "ID / primary key",
+        "authority": "Naming authority for code list entry",
+        "name": "Short name for feature type",
+        "description": "Description of feature type",
+        "links": "Link(s) to definition of feature type",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "WMDS facility type, type of observing facility"
+
+
+@dataclass
+class FeatureType(DomainModelBase):
+    id: str
+    authority: str
+    name: str
+    description: str
+    links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "ID / primary key",
+        "authority": "Naming authority for code list entry",
+        "name": "Short name for feature type",
+        "description": "Description of feature type",
+        "links": "Link(s) to definition of feature type",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class WmoRegion(DomainModelBase):
+    id: str
+    name: str
+    description: str
+    links: dict
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "ID / primary key",
+        "name": "Short name for WMO region",
+        "description": "Long name of WMO region",
+        "links": "Link(s) to definition of feature type",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class Territory(DomainModelBase):
+    id: str
+    ISO3c: str
+    name: str
+    description: str
+    wmo_region_id: Optional[str]
+    links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "ID / primary key",
+        "ISO3c": "ISO 3 character country code",
+        "name": "Short name for feature type",
+        "description": "Description of feature type",
+        "wmo_region_id": "WMO region that represents the territory",
+        "links": "Link(s) to definition of feature type",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class ObservedProperty(DomainModelBase):
+    id: str
+    authority: str
+    short_name: str
+    standard_name: Optional[str]
+    units: str
+    description: str
+    links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "ID / primary key",
+        "authority": "Naming authority for code list entry",
+        "short_name": "Short name representation of observed property, e.g. 'at' for air temperature",
+        "standard_name": "CF standard name (if applicable), e.g. 'air_temperature'",
+        "units": "Canonical units, e.g. 'Kelvin'",
+        "description": "Description of observed property",
+        "links": "Link(s) to definition / source of observed property",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class ObservingProcedure(DomainModelBase):
+    id: str
+    authority: str
+    name: str
+    description: str
+    links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "ID / primary key",
+        "authority": "Naming authority for code list entry",
+        "name": "Name of observing procedure",
+        "description": "Description of observing procedure",
+        "links": "Link(s) to further information",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
 class TimeZone(DomainModelBase):
-    id: int
+    id: str
     abbreviation: str
     name: str
-    offset: str
+    offset: float
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
     _comments = {
         "id": "ID / primary key",
         "abbreviation": "Abbreviation for time zone",
         "name": "Name / description of timezone",
-        "offset": "Offset from UTC"
+        "offset": "Offset from UTC (hours)",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
     }
     _comment = "placeholder"
+
+
+@dataclass
+class SourceType(DomainModelBase):
+    id: str
+    name: str
+    description: str
+    scheme: Optional[str]
+    links: Optional[str]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "ID / primary key",
+        "name": "Name of source type",
+        "description": "Description of source type, e.g. file etc",
+        "scheme": "IANA scheme (if applicable)",
+        "links": "Links providing further definition of source type",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class MediaType(DomainModelBase):
+    id: Optional[str]
+    name: Optional[str]
+    description: str
+    _comments = {
+        "id": "",
+        "name": "",
+        "description": "Type of media uploaded"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class ClimateZone(DomainModelBase):
+    id: Optional[str]
+    authority: str
+    name: Optional[str]
+    description: str
+    links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "",
+        "authority": "Naming authority for code list entry",
+        "name": "",
+        "description": "",
+        "links": "Links providing further definition of climate zone",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "wmdr.climate_zone"
+
+
+@dataclass
+class SurfaceCover(DomainModelBase):
+    id: Optional[str]
+    authority: str
+    name: Optional[str]
+    description: str
+    links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "",
+        "authority": "Naming authority for code list entry",
+        "name": "",
+        "description": "",
+        "links": "Links providing further definition of climate zone",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class SurfaceRoughness(DomainModelBase):
+    id: Optional[str]
+    authority: str
+    name: Optional[str]
+    description: str
+    links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "",
+        "authority": "Naming authority for code list entry",
+        "name": "",
+        "description": "",
+        "links": "Links providing further definition of climate zone",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class Topography(DomainModelBase):
+    id: Optional[str]
+    authority: str
+    name: Optional[str]
+    description: str
+    links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "",
+        "authority": "Naming authority for code list entry",
+        "name": "",
+        "description": "",
+        "links": "Links providing further definition of climate zone",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class Season(DomainModelBase):
+    id: Optional[str]
+    name: Optional[str]
+    description: str
+    links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "",
+        "name": "",
+        "description": "",
+        "links": "Links providing further definition of climate zone",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class Programme(DomainModelBase):
+    id: Optional[str]
+    authority: str
+    name: Optional[str]
+    description: str
+    links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "",
+        "authority": "Naming authority for code list entry",
+        "name": "",
+        "description": "",
+        "links": "Links providing further definition of climate zone",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class ObservingMethod(DomainModelBase):
+    id: Optional[str]
+    authority: str
+    name: Optional[str]
+    description: str
+    links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "",
+        "authority": "Naming authority for code list entry",
+        "name": "",
+        "description": "Description of observing method",
+        "links": "Links providing further definition of observing method",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class Exposure(DomainModelBase):
+    id: Optional[str]
+    name: Optional[str]
+    description: str
+    links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "",
+        "name": "",
+        "description": "Description of sensor exposure according to WMO-No. 8",
+        "links": "Links providing further definition of exposure class",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class ReferenceSurface(DomainModelBase):
+    id: Optional[str]
+    name: Optional[str]
+    description: str
+    _comments = {
+        "id": "",
+        "name": "",
+        "description": "Description of reference surface"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class Role(DomainModelBase):
+    id: str
+    authority: str
+    name: str
+    description: str
+    _comments = {
+        "id": "Primary key for this record",
+        "authority": "Namelist authority",
+        "name": "The name of the role",
+        "description": "Description of the role"
+    }
+    _comment = "The function performed by the responsible party."
+
+
+@dataclass
+class Media(DomainModelBase):
+    id: Optional[str]
+    media_type_id: Optional[str]
+    description: Optional[str]
+    created: Optional[datetime]
+    creator: Optional[str]
+    rights: Optional[int]
+    source: Optional[str]
+    data: Optional[dict]
+    _comments = {
+        "id": "",
+        "media_type_id": "",
+        "description": "",
+        "created": "",
+        "creator": "",
+        "rights": "",
+        "source": "",
+        "data": ""
+    }
+    _comment = "store for digital media, e.g. photos, reports, videos, etc"
 
 
 @dataclass
@@ -154,42 +617,189 @@ class Host(DomainModelBase):
     location: Optional[Geography]
     elevation: Optional[float]
     wigos_station_identifier: Optional[str]
-    facility_type: Optional[str]
+    facility_type_id: Optional[str]
     date_established: Optional[datetime]
     date_closed: Optional[datetime]
-    wmo_region: Optional[str]
-    territory: Optional[str]
+    wmo_region_id: Optional[str]
+    territory_id: Optional[str]
+    time_zone_id: Optional[str]
     valid_from: Optional[datetime]
     valid_to: Optional[datetime]
-    version: int
-    change_date: datetime
-    user_id: int
-    status_id: int
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
     comments: str
-    time_zone_id: Optional[int]
     _comments = {
         "id": "ID / primary key",
         "name": "Preferred name of host",
         "description": "Description of host",
         "links": "URI to host, e.g. to OSCAR/Surface",
         "location": "Location of station",
-        "elevation": "Elevation of station above mean sea level",
+        "elevation": "Elevation of station above mean sea level in meters",
         "wigos_station_identifier": "WIGOS station identifier",
-        "facility_type": "Type of observing facility, fixed land, mobile sea, etc",
+        "facility_type_id": "Type of observing facility, fixed land, mobile sea, etc",
         "date_established": "Date host was first established",
         "date_closed": "Date host was first established",
-        "wmo_region": "WMO region in which the host is located",
-        "territory": "Territory the host is located in",
+        "wmo_region_id": "WMO region in which the host is located",
+        "territory_id": "Territory the host is located in",
+        "time_zone_id": "Time zone the host is located in",
         "valid_from": "Date from which the details for this record are valid",
         "valid_to": "Date after which the details for this record are no longer valid",
-        "version": "Version number of this record",
-        "change_date": "Date this record was changed",
-        "user_id": "Which user last modified this record",
-        "status_id": "Whether this is the latest version or an archived version of the record",
-        "comments": "Free text comments on this record, for example description of changes made etc",
-        "time_zone_id": "Time zone the host is located in"
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
     }
     _comment = "wmdr.observing_facility"
+
+
+@dataclass
+class HostEnvironment(DomainModelBase):
+    id: str
+    host: str
+    climate_zone_id: Optional[str]
+    surface_cover_id: Optional[str]
+    surface_roughness_id: Optional[str]
+    topography_id: Optional[str]
+    season_id: Optional[str]
+    valid_from: Optional[datetime]
+    valid_to: Optional[datetime]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "Primary key for this record",
+        "host": "Host associated with this record",
+        "climate_zone_id": "Climate zone that the associated host is located in",
+        "surface_cover_id": "Type of sueface cover",
+        "surface_roughness_id": "Typical surface roughness of the site surrounding the host",
+        "topography_id": "Topography of the environment surrounding the host",
+        "season_id": "Season that is applicable to this record (e.g. all, winter, spring, summer, autumn)",
+        "valid_from": "Date the this record is valid from",
+        "valid_to": "date that this record is valid to",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "Description of the environment at the specified host"
+
+
+@dataclass
+class HostAffiliation(DomainModelBase):
+    id: str
+    host_id: str
+    programme_id: Optional[str]
+    valid_from: Optional[datetime]
+    valid_to: Optional[datetime]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "Primary key for this record",
+        "host_id": "Host described by this record",
+        "programme_id": "Observing programme that this host is affiliated with",
+        "valid_from": "Date from which the details for this record are valid",
+        "valid_to": "Date after which the details for this record are no longer valid",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "Which programs this host is affiliated with"
+
+
+@dataclass
+class HostAlias(DomainModelBase):
+    id: str
+    host_id: str
+    alternative: Optional[str]
+    alternative_name: Optional[str]
+    valid_from: Optional[datetime]
+    valid_to: Optional[datetime]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "Primary key for this record",
+        "host_id": "Primary ID by which the host is known",
+        "alternative": "Alternative ID by which the host is known",
+        "alternative_name": "Alternative name by which the host is known",
+        "valid_from": "Date the alternative id/name was used from",
+        "valid_to": "Date the alternative id/name was used to",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "table to track known aliases for hosts"
+
+
+@dataclass
+class HostResponsibleParty(DomainModelBase):
+    id: str
+    responsible_party_id: str
+    role_id: str
+    host_id: str
+    valid_from: Optional[datetime]
+    valid_to: Optional[datetime]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "Unique identifier for this record",
+        "responsible_party_id": "The responsible party",
+        "role_id": "The role this responsible party plays",
+        "host_id": "The host that this record corresponds to",
+        "valid_from": "Date this record is valid from",
+        "valid_to": "Date this record is valid to",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class HostMedia(DomainModelBase):
+    id: str
+    host_id: Optional[str]
+    media_id: Optional[str]
+    valid_from: Optional[datetime]
+    valid_to: Optional[datetime]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "Primary key for this record",
+        "host_id": "",
+        "media_id": "",
+        "valid_from": "",
+        "valid_to": "",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "Link table between hosts and media"
 
 
 @dataclass
@@ -204,8 +814,12 @@ class Observer(DomainModelBase):
     model: Optional[str]
     serial_number: Optional[str]
     firmware_version: Optional[str]
-    uncertainty: Optional[str]
-    observing_method: Optional[str]
+    control_schedule_id: Optional[str]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
     _comments = {
         "id": "ID / primary key",
         "name": "Name of sensor",
@@ -217,10 +831,126 @@ class Observer(DomainModelBase):
         "model": "Model of sensor",
         "serial_number": "Serial number of sensor",
         "firmware_version": "Firmware version of software installed in sensor",
-        "uncertainty": "Standard uncertainty in measurements from sensor",
-        "observing_method": "Primary method/principles by which the sensor makes measurements"
+        "control_schedule_id": "Link to information on calibration schedule and details",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
     }
     _comment = "wmdr.equipment"
+
+
+@dataclass
+class ControlSchedule(DomainModelBase):
+    id: Optional[str]
+    name: Optional[str]
+    description: str
+    _comments = {
+        "id": "",
+        "name": "",
+        "description": "Description of control schedule"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class ObserverCharacteristics(DomainModelBase):
+    id: str
+    observer_id: str
+    observed_property_id: Optional[str]
+    observing_method_id: Optional[str]
+    measurement_units: Optional[int]
+    drift_per_unit_time: Optional[float]
+    unit_time: Optional[int]
+    valid_min: Optional[float]
+    valid_max: Optional[float]
+    measurement_uncertainty: Optional[float]
+    measurement_accuracy: Optional[float]
+    measurement_repeatability: Optional[float]
+    measurement_resolution: Optional[float]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "Primary key for this record",
+        "observer_id": "The observer to which this record applies",
+        "observed_property_id": "The observed parameter to which this record applies",
+        "observing_method_id": "Primary method/principles by which the sensor makes measurements",
+        "measurement_units": "The units used in this record",
+        "drift_per_unit_time": "Sensor drift per unit time, units specified by measurement units, unit time by unit time",
+        "unit_time": "Unit time for drift per unit time (seconds)",
+        "valid_min": "Minimum observable value by sensor, in units specificed by measurement units",
+        "valid_max": "Maximum observable value by sensor, in units specificed by measurement units",
+        "measurement_uncertainty": "Measurement uncertainty for measurements from this sensor, 2 sigma. Units as per measuremenet units",
+        "measurement_accuracy": "Measurement accuracy (trueness) for measurements from this sensor, 2 sigma. Units as per measuremenet units",
+        "measurement_repeatability": "Measurement repeatability (precision) for measurements from this sensor, 2 sigma. Units as per measuremenet units",
+        "measurement_resolution": "Minimum change detectable for measurements from this sensor. Units as per measurement units",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "Table to record sensor specifications"
+
+
+@dataclass
+class ObserverResponsibleParty(DomainModelBase):
+    id: Optional[str]
+    responsible_party_id: str
+    role_id: str
+    observer_id: str
+    valid_from: Optional[datetime]
+    valid_to: Optional[datetime]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "",
+        "responsible_party_id": "",
+        "role_id": "",
+        "observer_id": "The observer that this record corresponds to",
+        "valid_from": "Date this record is valid from",
+        "valid_to": "Date this record is valid to",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class ObserverMedia(DomainModelBase):
+    id: str
+    observer_id: Optional[str]
+    media_id: Optional[str]
+    valid_from: Optional[datetime]
+    valid_to: Optional[datetime]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "Primary key for this record",
+        "observer_id": "",
+        "media_id": "",
+        "valid_from": "",
+        "valid_to": "",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "Link table between hosts and media"
 
 
 @dataclass
@@ -228,10 +958,20 @@ class Collection(DomainModelBase):
     id: str
     name: str
     links: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
     _comments = {
         "id": "ID / primary key",
         "name": "Name of collection",
-        "links": "Link(s) to further information on collection"
+        "links": "Link(s) to further information on collection",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
     }
     _comment = "placeholder"
 
@@ -239,50 +979,63 @@ class Collection(DomainModelBase):
 @dataclass
 class Feature(DomainModelBase):
     id: str
-    type_id: int
-    geometry: Geography
-    elevation: Optional[float]
-    parent_id: Optional[str]
     name: Optional[str]
     description: Optional[str]
     links: Optional[dict]
+    feature_type_id: str
+    geometry: Geography
+    elevation: Optional[float]
+    parent_id: Optional[str]
+    properties: Optional[dict]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
     _comments = {
         "id": "ID / primary key",
-        "type_id": "enumerated feature type",
-        "geometry": "",
-        "elevation": "Elevation of feature above mean sea level",
-        "parent_id": "Parent feature for this feature if nested",
         "name": "Name of feature",
         "description": "Description of feature",
-        "links": "Link(s) to further information on feature"
+        "links": "Link(s) to further information on feature",
+        "feature_type_id": "enumerated feature type",
+        "geometry": "",
+        "elevation": "Meam elevation of feature above mean sea level",
+        "parent_id": "Parent feature for this feature if nested",
+        "properties": "Array of named values consistent with that defined for the feature type",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
     }
     _comment = "table to contain definition of different geographic features"
 
 
 @dataclass
-class SourceType(DomainModelBase):
-    id: str
-    description: Optional[str]
-    _comments = {
-        "id": "ID / primary key",
-        "description": "Description of source type, e.g. file etc"
-    }
-    _comment = "placeholder"
-
-
-@dataclass
 class Source(DomainModelBase):
     id: str
-    source_type_id: int
     name: str
+    description: str
+    source_type_id: str
     links: Optional[dict]
     processor: Optional[str]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
     _comments = {
         "id": "ID / primary key",
-        "source_type_id": "The type of source",
         "name": "Name of source",
+        "description": "Description of source type, e.g. file etc",
+        "source_type_id": "The type of source",
         "links": "Link(s) to further information on source",
-        "processor": "Name of processor used to ingest the data"
+        "processor": "Name of processor used to ingest the data",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
     }
     _comment = "placeholder"
 
@@ -292,7 +1045,7 @@ class Observation(DomainModelBase):
     id: str
     location: Geography
     elevation: Optional[float]
-    observation_type_id: Optional[int]
+    observation_type_id: Optional[str]
     phenomenon_start: Optional[datetime]
     phenomenon_end: datetime
     result_value: float
@@ -304,22 +1057,22 @@ class Observation(DomainModelBase):
     valid_to: Optional[datetime]
     host_id: str
     observer_id: Optional[str]
-    observed_property_id: int
-    observing_procedure_id: Optional[int]
-    report_id: Optional[str]
+    observed_property_id: str
+    observing_procedure_id: Optional[str]
     collection_id: Optional[str]
     parameter: Optional[dict]
-    feature_of_interest_id: Optional[str]
-    version: int
-    change_date: datetime
-    user_id: int
-    status_id: int
+    feature_id: Optional[str]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
     comments: str
-    source_id: int
+    _source_id: str
+    _source_identifier: str
     _comments = {
         "id": "ID / primary key",
         "location": "Location of observation",
-        "elevation": "Elevation of observation above mean sea level",
+        "elevation": "Elevation of observation above mean sea level (in meters)",
         "observation_type_id": "Type of observation",
         "phenomenon_start": "Start time of the phenomenon being observed or observing period, if missing assumed instantaneous with time given by phenomenon_end",
         "phenomenon_end": "End time of the phenomenon being observed or observing period",
@@ -334,15 +1087,133 @@ class Observation(DomainModelBase):
         "observer_id": "Observer associated with making the observation, equivalent to OGC OMS 'observer'",
         "observed_property_id": "The phenomenon, or thing, being observed",
         "observing_procedure_id": "Procedure used to make the observation",
-        "report_id": "Parent report ID, used to link coincident observations together",
-        "collection_id": "Primary collection or dataset that this observation belongs to",
+        "collection_id": "Primary collection or dataset that this observation belongs to. Note: this is different to the OGC OMS collection concept.",
         "parameter": "List of key/ value pairs in dict",
-        "feature_of_interest_id": "Feature that this observation is associated with",
-        "version": "Version number of this record",
-        "change_date": "Date this record was changed",
-        "user_id": "Which user last modified this record",
-        "status_id": "Whether this is the latest version or an archived version of the record",
+        "feature_id": "Feature of interest that this observation is associated with",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
         "comments": "Free text comments on this record, for example description of changes made etc",
-        "source_id": "The source of this record"
+        "_source_id": "The source of this record",
+        "_source_identifier": "The original identifier for the record from the data source"
     }
     _comment = "table to store observations"
+
+
+@dataclass
+class Deployment(DomainModelBase):
+    id: str
+    host_id: Optional[str]
+    observer_id: Optional[str]
+    valid_from: Optional[datetime]
+    valid_to: Optional[datetime]
+    installation_height: Optional[float]
+    reference_surface_id: Optional[str]
+    exposure_id: Optional[str]
+    configuration: Optional[str]
+    maintenance_schedule_id: Optional[str]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "Unique ID / primary key for deployment",
+        "host_id": "",
+        "observer_id": "",
+        "valid_from": "",
+        "valid_to": "",
+        "installation_height": "Installation height above reference surface (in meters)",
+        "reference_surface_id": "",
+        "exposure_id": "",
+        "configuration": "Textual description of sensor installation and configuration",
+        "maintenance_schedule_id": "",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "Table to track deployments of an observer to a host"
+
+
+@dataclass
+class MaintenanceSchedule(DomainModelBase):
+    id: Optional[str]
+    name: Optional[str]
+    description: str
+    _comments = {
+        "id": "",
+        "name": "",
+        "description": "Description of maintenance schedule"
+    }
+    _comment = "placeholder"
+
+
+@dataclass
+class DeploymentMedia(DomainModelBase):
+    id: str
+    deployment_id: Optional[str]
+    media_id: Optional[int]
+    valid_from: Optional[datetime]
+    valid_to: Optional[datetime]
+    _version: int
+    _change_date: datetime
+    _user_id: str
+    _status_id: str
+    comments: str
+    _comments = {
+        "id": "Primary key for this record",
+        "deployment_id": "",
+        "media_id": "",
+        "valid_from": "",
+        "valid_to": "",
+        "_version": "Version number of this record",
+        "_change_date": "Date this record was changed",
+        "_user_id": "Which user/agent last modified this record",
+        "_status_id": "Whether this is the latest version or an archived version of the record",
+        "comments": "Free text comments on this record, for example description of changes made etc"
+    }
+    _comment = "Link table between hosts and media"
+
+
+@dataclass
+class Record(DomainModelBase):
+    id: str
+    time: str
+    title: str
+    location: Geography
+    created: str
+    updated: str
+    resource_type: str
+    description: str
+    keywords: str
+    language: str
+    external_ids: dict
+    themes: dict
+    formats: dict
+    providers: dict
+    license: str
+    rights: str
+    links: dict
+    _comments = {
+        "id": "A unique identifier of the catalogue record.",
+        "time": "The temporal extent of the resource. Can be null if there is no associated temporal extent.",
+        "title": "A human-readable name given to the resource.",
+        "location": "A geometry associated with the resource that is used for discovery. Can be null if there is no associated geometry.",
+        "created": "Date of creation of this record.",
+        "updated": "The most recent date on which the record was changed.",
+        "resource_type": "The nature or genre of the resource. The value should be a code, convenient for filtering records. Where available, a link to the canonical URI of the record type resource will be added to the 'links' property.",
+        "description": "A free-text account of the resource.",
+        "keywords": "The topic or topics of the resource. Typically represented using free-form keywords, tags, key phrases, or classification codes. Semi-colon delimited",
+        "language": "The natural language used for textual values (e.g. titles, descriptions, etc.) of the resource. ISO 639-1/639-2 codes should be used.",
+        "external_ids": "An identifier for the resource assigned by an external (to the catalogue) entity.",
+        "themes": "A knowledge organization system used to classify the resource.",
+        "formats": "A list of available distributions of the resource.",
+        "providers": "A list of providers qualified by their role in association to the record.",
+        "license": "A legal document under which the resource is made available. The value should be a code, convenient for filtering the records. Where applicable, the use of the identifiers from the SPDX License List is recommended. If multiple licenses apply, it is recommended to use ''various'.  Where available, links to a URI of each applicable license should be added to the 'links' property.",
+        "rights": "A statement that concerns all rights not addressed by the license such as a copyright statement.",
+        "links": "A list of links for accessing the resource (e.g. download link, access link) in one of the supported distribution formats and/or links to other resources associated with this resource. Also, a list of links for navigating the API (e.g. prev, next, etc.).  Since the specification requires that at least the self link be present then the min items for this list should be one."
+    }
+    _comment = "The function performed by the responsible party."

--- a/opencdms/requirements/db.txt
+++ b/opencdms/requirements/db.txt
@@ -2,5 +2,6 @@
 faker
 geoalchemy2>=0.13.0
 psycopg2-binary
+sqlalchemy_json
 sqlalchemy_utils
 alchemyjsonschema


### PR DESCRIPTION
Data model update. Some separation into different schema's is still required, e.g. WCMP elements.
blob / data object in media now dict for storing media file metadata (e.g. path etc).
Update .gitignore