### PR TITLE
Manually add opencdms-tmp files to main opencdms repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Ignore db
 *.db
+.DS_Store
 
 
 # -- Standard Python .gitignore --# 

--- a/install/build_db.py
+++ b/install/build_db.py
@@ -1,0 +1,88 @@
+import os
+from sqlalchemy import create_engine, text
+from sqlalchemy_utils import database_exists, create_database, drop_database
+from sqlalchemy.orm import sessionmaker
+
+from opencdms.adapters import opencdmsdb
+
+
+# set connection details
+UID = os.environ["POSTGRES_USER"]
+PWD = os.environ["POSTGRES_PASSWORD"]
+DBNAME = os.environ["POSTGRES_DB"]
+DBHOST = os.environ["POSTGRES_HOST"]
+DBPORT = os.environ["POSTGRES_PORT"]
+
+engine = create_engine(f"postgresql+psycopg2://{UID}:{PWD}@{DBHOST}:{DBPORT}/{DBNAME}", echo=True)
+# check whether we want to start clean
+CLEAN = True
+if CLEAN:
+    if database_exists(engine.url):
+        drop_database(engine.url)
+    create_database(engine.url)
+
+with engine.begin() as conn:
+    # Create schema
+    conn.execute(text("CREATE SCHEMA IF NOT EXISTS cdm"))
+    # Add PostGIS extension
+    conn.execute(text("CREATE EXTENSION Postgis;"))
+
+# create tables
+opencdmsdb.mapper_registry.metadata.create_all(engine)
+
+opencdmsdb.start_mappers()
+
+session = sessionmaker(bind=engine)()
+cursor = session.connection().connection.cursor()
+
+code_tables = {
+    "cdm.user": "user.csv",
+    "cdm.status": "status.csv",
+    "cdm.observation_type": "observation_type.csv",
+    "cdm.facility_type": "facility_type.csv",
+    "cdm.feature_type": "feature_type.csv",
+    "cdm.wmo_region": "wmo_region.csv",
+    "cdm.territory": "territory.csv",
+    "cdm.observed_property": "observed_property.csv",
+    "cdm.observing_procedure": "observing_procedure.csv",
+    "cdm.time_zone": "time_zone.csv",
+    "cdm.source_type": "source_type.csv",
+    "cdm.media_type": "media_type.csv",
+    "cdm.climate_zone": "climate_zone.csv",
+    "cdm.surface_cover": "surface_cover.csv",
+    "cdm.surface_roughness": "surface_roughness.csv",
+    "cdm.topography": "topography.csv",
+    "cdm.season": "season.csv",
+    "cdm.programme": "programme.csv",
+    "cdm.observing_method": "observing_method.csv",
+    "cdm.exposure": "exposure.csv",
+    "cdm.reference_surface": "reference_surface.csv",
+    "cdm.role": "role.csv"
+}
+# note, order is important
+data_tables = {
+    "cdm.host": ["hosts.csv"],
+    "cdm.source": ["source.csv"],
+    "cdm.observer": ["observer.csv"],
+    "cdm.deployment": ["deployment.csv"],
+    "cdm.observer_characteristics": ["observer_characteristics.csv"],
+    # "cdm.observation": ["CA_6016527_1990.csv"],
+    "cdm.feature": ["features.csv"]
+}
+
+for key, value in code_tables.items():
+    with open(f"/local/app/data/code_tables/{value}") as fh:
+        cursor.copy_expert(f"COPY {key} FROM STDIN WITH CSV HEADER DELIMITER AS '|' NULL AS 'NA' QUOTE E'\b'", fh)
+
+for key, value in data_tables.items():
+    if isinstance(value, list):
+        for item in value:
+            with open(f"/local/app/data/data_tables/{item}") as fh:
+                cursor.copy_expert(f"COPY {key} FROM STDIN WITH CSV HEADER DELIMITER AS '|' NULL AS 'NA' QUOTE E'\b'", fh)
+    else:
+        with open(f"/local/app/data/data_tables/{value}") as fh:
+            cursor.copy_expert(f"COPY {key} FROM STDIN WITH CSV HEADER DELIMITER AS '|' NULL AS 'NA' QUOTE E'\b'", fh)
+
+session.commit()
+session.close()
+

--- a/install/config.yaml
+++ b/install/config.yaml
@@ -1,0 +1,8 @@
+topics:
+  - fs:
+      -
+        id: 1
+        bucket: incoming
+        prefix: station_abc
+        suffix: csv
+        processor: import_observations

--- a/install/containers/mosquitto/Dockerfile
+++ b/install/containers/mosquitto/Dockerfile
@@ -1,0 +1,5 @@
+FROM eclipse-mosquitto
+
+COPY entrypoint.sh /docker-entrypoint.sh
+COPY mosquitto /mosquitto
+COPY mosquitto/config /mosquitto/config

--- a/install/containers/mosquitto/entrypoint.sh
+++ b/install/containers/mosquitto/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+mosquitto_passwd -b -c /mosquitto/config/password.txt $OPENCDMS_BROKER_USERNAME $OPENCDMS_BROKER_PASSWORD
+mosquitto_passwd -b /mosquitto/config/password.txt everyone everyone
+
+sed -i "s#_OPENCDMS_BROKER_QUEUE_MAX#$OPENCDMS_BROKER_QUEUE_MAX#" /mosquitto/config/mosquitto.conf
+sed -i "s#_OPENCDMS_BROKER_USERNAME#$OPENCDMS_BROKER_USERNAME#" /mosquitto/config/acl.conf
+
+/usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf

--- a/install/containers/mosquitto/mosquitto/config/acl.conf
+++ b/install/containers/mosquitto/mosquitto/config/acl.conf
@@ -1,0 +1,10 @@
+user everyone
+topic read public/#
+topic read origin/#
+
+user _OPENCDMS_BROKER_USERNAME
+topic readwrite origin/#
+topic readwrite public/#
+topic readwrite internal/#
+topic readwrite fs/#
+topic read $SYS/#

--- a/install/containers/mosquitto/mosquitto/config/mosquitto.conf
+++ b/install/containers/mosquitto/mosquitto/config/mosquitto.conf
@@ -1,0 +1,14 @@
+persistence true
+persistence_location /mosquitto/data/
+log_dest file /mosquitto/log/mosquitto.log
+log_dest stdout
+log_timestamp_format %Y-%m-%dT%H:%M:%S
+password_file /mosquitto/config/password.txt
+max_queued_messages _OPENCDMS_BROKER_QUEUE_MAX
+
+# ACLs
+acl_file /mosquitto/config/acl.conf
+
+## MQTT Listener
+listener 1883
+protocol mqtt

--- a/install/containers/pygeoapi/Dockerfile
+++ b/install/containers/pygeoapi/Dockerfile
@@ -1,0 +1,38 @@
+FROM wmoim/dim_eccodes_baseimage:2.28.0
+
+ENV TZ="Etc/UTC" \
+    DEBIAN_FRONTEND="noninteractive" \
+    PYGEOAPI_CONFIG="/config/pygeoapi-config.yml" \
+    PYGEOAPI_OPENAPI="/config/openapi-config.yml" \
+    DEBIAN_PACKAGES="cron bash vim git libffi-dev python3-cryptography libssl-dev libudunits2-0 python3-paho-mqtt python3-dateparser python3-tz python3-setuptools" \
+    POSTGRES_USER=opencdms \
+    POSTGRES_PASSWORD=insecure-change-me \
+    POSTGRES_DB=opencdms \
+    POSTGRES_HOST=opencdms-database \
+    POSTGRES_PORT=5432
+
+RUN echo "Acquire::Check-Valid-Until \"false\";\nAcquire::Check-Date \"false\";" | cat > /etc/apt/apt.conf.d/10no--check-valid-until \
+    && apt-get update -y \
+    && apt-get install -y ${DEBIAN_PACKAGES} \
+
+    && apt-get install -y python3 python3-pip libpq-dev \
+    && pip3 install --no-cache-dir click==8.1.3 \
+    && pip3 install --no-cache-dir https://github.com/wmo-im/csv2bufr/archive/pygeoapi-debug.zip \
+    && pip3 install --no-cache-dir https://github.com/opencdms/opencdms/archive/main.zip \
+    && pip3 install --no-cache-dir https://github.com/david-i-berry/opencdms-pygeoapi/archive/wip.zip
+
+WORKDIR /tmp
+COPY requirements-providers.txt .
+COPY processes/ /tmp/processes/
+
+RUN pip3 install -r requirements-providers.txt
+RUN cd /tmp/processes/cdm && python3 setup.py install
+RUN cd /tmp/processes/OpenCDMSWMDR && python3 setup.py install
+
+# clean up
+RUN rm -R /tmp
+
+ADD ./config /config
+
+# create openapi config file (needs to be done after initilisation of DB, => commented out)
+#RUN pygeoapi openapi generate $PYGEOAPI_CONFIG > $PYGEOAPI_OPENAPI

--- a/install/containers/pygeoapi/config/openapi-config.yml
+++ b/install/containers/pygeoapi/config/openapi-config.yml
@@ -1,0 +1,1651 @@
+components:
+  parameters:
+    bbox:
+      description: Only features that have a geometry that intersects the bounding
+        box are selected.The bounding box is provided as four or six numbers, depending
+        on whether the coordinate reference system includes a vertical axis (height
+        or depth).
+      explode: false
+      in: query
+      name: bbox
+      required: false
+      schema:
+        items:
+          type: number
+        maxItems: 6
+        minItems: 4
+        type: array
+      style: form
+    bbox-crs:
+      description: Indicates the coordinate reference system for the given bbox coordinates.
+      explode: false
+      in: query
+      name: bbox-crs
+      required: false
+      schema:
+        format: uri
+        type: string
+      style: form
+    bbox-crs-epsg:
+      description: Indicates the EPSG for the given bbox coordinates.
+      explode: false
+      in: query
+      name: bbox-crs
+      required: false
+      schema:
+        default: 4326
+        type: integer
+      style: form
+    crs:
+      description: Indicates the coordinate reference system for the results.
+      explode: false
+      in: query
+      name: crs
+      required: false
+      schema:
+        format: uri
+        type: string
+      style: form
+    f:
+      description: The optional f parameter indicates the output format which the
+        server shall provide as part of the response document.  The default format
+        is GeoJSON.
+      explode: false
+      in: query
+      name: f
+      required: false
+      schema:
+        default: json
+        enum:
+        - json
+        - html
+        - jsonld
+        type: string
+      style: form
+    lang:
+      description: The optional lang parameter instructs the server return a response
+        in a certain language, if supported.  If the language is not among the available
+        values, the Accept-Language header language will be used if it is supported.
+        If the header is missing, the default server language is used. Note that providers
+        may only support a single language (or often no language at all), that can
+        be different from the server language.  Language strings can be written in
+        a complex (e.g. "fr-CA,fr;q=0.9,en-US;q=0.8,en;q=0.7"), simple (e.g. "de")
+        or locale-like (e.g. "de-CH" or "fr_BE") fashion.
+      in: query
+      name: lang
+      required: false
+      schema:
+        default: en-US
+        enum:
+        - en-US
+        type: string
+    offset:
+      description: The optional offset parameter indicates the index within the result
+        set from which the server shall begin presenting results in the response document.  The
+        first element has an index of 0 (default).
+      explode: false
+      in: query
+      name: offset
+      required: false
+      schema:
+        default: 0
+        minimum: 0
+        type: integer
+      style: form
+    properties:
+      description: The properties that should be included for each feature. The parameter
+        value is a comma-separated list of property names.
+      explode: false
+      in: query
+      name: properties
+      required: false
+      schema:
+        items:
+          type: string
+        type: array
+      style: form
+    skipGeometry:
+      description: This option can be used to skip response geometries for each feature.
+      explode: false
+      in: query
+      name: skipGeometry
+      required: false
+      schema:
+        default: false
+        type: boolean
+      style: form
+    vendorSpecificParameters:
+      description: Additional "free-form" parameters that are not explicitly defined
+      in: query
+      name: vendorSpecificParameters
+      schema:
+        additionalProperties: true
+        type: object
+      style: form
+  responses:
+    '200':
+      description: successful operation
+    Queryables:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/queryables'
+      description: successful queryables operation
+    default:
+      content:
+        application/json:
+          schema:
+            $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/exception.yaml
+      description: Unexpected error
+  schemas:
+    queryable:
+      properties:
+        description:
+          description: a human-readable narrative describing the queryable
+          type: string
+        language:
+          default:
+          - en
+          description: the language used for the title and description
+          type: string
+        queryable:
+          description: the token that may be used in a CQL predicate
+          type: string
+        title:
+          description: a human readable title for the queryable
+          type: string
+        type:
+          description: the data type of the queryable
+          type: string
+        type-ref:
+          description: a reference to the formal definition of the type
+          format: url
+          type: string
+      required:
+      - queryable
+      - type
+      type: object
+    queryables:
+      properties:
+        queryables:
+          items:
+            $ref: '#/components/schemas/queryable'
+          type: array
+      required:
+      - queryables
+      type: object
+info:
+  contact:
+    email: you@example.org
+    name: OpenCDMS
+    url: https://www.opencdms.org
+  description: PygeoAPI instance deployed as part of the beta.opencdms.org instance
+  license:
+    name: Unified WMO Data Policy
+    url: https://public.wmo.int/en/our-mandate/what-we-do/observations/Unified-WMO-Data-Policy-Resolution
+  termsOfService: https://public.wmo.int/en/our-mandate/what-we-do/observations/Unified-WMO-Data-Policy-Resolution
+  title: OpenCDMS beta API
+  version: 0.15.dev0
+  x-keywords:
+  - wmo
+  - wis 2.0
+openapi: 3.0.2
+paths:
+  /:
+    get:
+      description: Landing page
+      operationId: getLandingPage
+      parameters:
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/LandingPage
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Landing page
+      tags:
+      - server
+  /collections:
+    get:
+      description: Collections
+      operationId: getCollections
+      parameters:
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/LandingPage
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Collections
+      tags:
+      - server
+  /collections/observations:
+    get:
+      description: Extract of hourly observations from the 'Hourly Climate Observations'
+        dataset provided by Environment and Climate Change Canada.
+      operationId: describeObservationsCollection
+      parameters:
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Collection
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Hourly climate data from Ontario (ECCC) metadata
+      tags:
+      - observations
+  /collections/observations/items:
+    get:
+      description: Extract of hourly observations from the 'Hourly Climate Observations'
+        dataset provided by Environment and Climate Change Canada.
+      operationId: getObservationsFeatures
+      parameters:
+      - &id001
+        description: The optional f parameter indicates the output format which the
+          server shall provide as part of the response document.  The default format
+          is GeoJSON.
+        explode: false
+        in: query
+        name: f
+        required: false
+        schema:
+          default: json
+          enum:
+          - json
+          - html
+          - jsonld
+          - csv
+          type: string
+        style: form
+      - &id002
+        description: The optional lang parameter instructs the server return a response
+          in a certain language, if supported.  If the language is not among the available
+          values, the Accept-Language header language will be used if it is supported.
+          If the header is missing, the default server language is used. Note that
+          providers may only support a single language (or often no language at all),
+          that can be different from the server language.  Language strings can be
+          written in a complex (e.g. "fr-CA,fr;q=0.9,en-US;q=0.8,en;q=0.7"), simple
+          (e.g. "de") or locale-like (e.g. "de-CH" or "fr_BE") fashion.
+        in: query
+        name: lang
+        required: false
+        schema:
+          default: en-US
+          enum:
+          - en-US
+          type: string
+      - $ref: '#/components/parameters/bbox'
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/limit
+      - $ref: '#/components/parameters/crs'
+      - $ref: '#/components/parameters/bbox-crs'
+      - description: The properties that should be included for each feature. The
+          parameter value is a comma-separated list of property names.
+        explode: false
+        in: query
+        name: properties
+        required: false
+        schema:
+          items:
+            enum:
+            - id
+            - elevation
+            - observation_type_id
+            - phenomenon_start
+            - phenomenon_end
+            - result_value
+            - result_uom
+            - result_description
+            - result_quality
+            - result_time
+            - valid_from
+            - valid_to
+            - host_id
+            - observer_id
+            - observed_property_id
+            - observing_procedure_id
+            - collection_id
+            - parameter
+            - feature_id
+            - _version
+            - _change_date
+            - _user_id
+            - _status_id
+            - comments
+            - _source_id
+            - _source_identifier
+            type: string
+          type: array
+        style: form
+      - $ref: '#/components/parameters/vendorSpecificParameters'
+      - $ref: '#/components/parameters/skipGeometry'
+      - $ref: https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/parameters/sortby.yaml
+      - $ref: '#/components/parameters/offset'
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/datetime
+      - explode: false
+        in: query
+        name: id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: elevation
+        required: false
+        schema:
+          type: NUMERIC
+        style: form
+      - explode: false
+        in: query
+        name: observation_type_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: phenomenon_start
+        required: false
+        schema:
+          type: TIMESTAMP
+        style: form
+      - explode: false
+        in: query
+        name: phenomenon_end
+        required: false
+        schema:
+          type: TIMESTAMP
+        style: form
+      - explode: false
+        in: query
+        name: result_value
+        required: false
+        schema:
+          type: NUMERIC
+        style: form
+      - explode: false
+        in: query
+        name: result_uom
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: result_description
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: result_quality
+        required: false
+        schema:
+          type: JSONB
+        style: form
+      - explode: false
+        in: query
+        name: result_time
+        required: false
+        schema:
+          type: TIMESTAMP
+        style: form
+      - explode: false
+        in: query
+        name: valid_from
+        required: false
+        schema:
+          type: TIMESTAMP
+        style: form
+      - explode: false
+        in: query
+        name: valid_to
+        required: false
+        schema:
+          type: TIMESTAMP
+        style: form
+      - explode: false
+        in: query
+        name: host_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: observer_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: observed_property_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: observing_procedure_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: collection_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: parameter
+        required: false
+        schema:
+          type: JSONB
+        style: form
+      - explode: false
+        in: query
+        name: feature_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: _version
+        required: false
+        schema:
+          type: INTEGER
+        style: form
+      - explode: false
+        in: query
+        name: _change_date
+        required: false
+        schema:
+          type: TIMESTAMP
+        style: form
+      - explode: false
+        in: query
+        name: _user_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: _status_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: comments
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: _source_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: _source_identifier
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Features
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Hourly climate data from Ontario (ECCC) items
+      tags:
+      - observations
+    post:
+      description: Extract of hourly observations from the 'Hourly Climate Observations'
+        dataset provided by Environment and Climate Change Canada.
+      operationId: addObservationsFeatures
+      requestBody:
+        content:
+          application/geo+json:
+            schema: {}
+        description: Adds item to collection
+        required: true
+      responses:
+        '201':
+          description: Successful creation
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Add Hourly climate data from Ontario (ECCC) items
+      tags:
+      - observations
+  /collections/observations/items/{featureId}:
+    delete:
+      description: Extract of hourly observations from the 'Hourly Climate Observations'
+        dataset provided by Environment and Climate Change Canada.
+      operationId: deleteObservationsFeatures
+      parameters:
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/featureId
+      responses:
+        '200':
+          description: Successful delete
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Delete Hourly climate data from Ontario (ECCC) items
+      tags:
+      - observations
+    get:
+      description: Extract of hourly observations from the 'Hourly Climate Observations'
+        dataset provided by Environment and Climate Change Canada.
+      operationId: getObservationsFeature
+      parameters:
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/featureId
+      - $ref: '#/components/parameters/crs'
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Feature
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Hourly climate data from Ontario (ECCC) item by id
+      tags:
+      - observations
+    put:
+      description: Extract of hourly observations from the 'Hourly Climate Observations'
+        dataset provided by Environment and Climate Change Canada.
+      operationId: updateObservationsFeatures
+      parameters:
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/featureId
+      requestBody:
+        content:
+          application/geo+json:
+            schema: {}
+        description: Updates item in collection
+        required: true
+      responses:
+        '204':
+          description: Successful update
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Update Hourly climate data from Ontario (ECCC) items
+      tags:
+      - observations
+  /collections/observations/queryables:
+    get:
+      description: Extract of hourly observations from the 'Hourly Climate Observations'
+        dataset provided by Environment and Climate Change Canada.
+      operationId: getObservationsQueryables
+      parameters:
+      - *id001
+      - *id002
+      responses:
+        '200':
+          $ref: '#/components/responses/Queryables'
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Hourly climate data from Ontario (ECCC) queryables
+      tags:
+      - observations
+  /collections/observer:
+    get:
+      description: Data table of observers
+      operationId: describeObserverCollection
+      parameters:
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Collection
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Observer metadata
+      tags:
+      - observer
+  /collections/observer/items:
+    get:
+      description: Data table of observers
+      operationId: getObserverFeatures
+      parameters:
+      - *id001
+      - *id002
+      - $ref: '#/components/parameters/bbox'
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/limit
+      - $ref: '#/components/parameters/crs'
+      - $ref: '#/components/parameters/bbox-crs'
+      - description: The properties that should be included for each feature. The
+          parameter value is a comma-separated list of property names.
+        explode: false
+        in: query
+        name: properties
+        required: false
+        schema:
+          items:
+            enum:
+            - id
+            - name
+            - description
+            - links
+            - elevation
+            - manufacturer
+            - model
+            - serial_number
+            - firmware_version
+            - control_schedule_id
+            - _version
+            - _change_date
+            - _user_id
+            - _status_id
+            - comments
+            type: string
+          type: array
+        style: form
+      - $ref: '#/components/parameters/vendorSpecificParameters'
+      - $ref: '#/components/parameters/skipGeometry'
+      - $ref: https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/parameters/sortby.yaml
+      - $ref: '#/components/parameters/offset'
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/datetime
+      - explode: false
+        in: query
+        name: id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: name
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: description
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: links
+        required: false
+        schema:
+          type: JSONB
+        style: form
+      - explode: false
+        in: query
+        name: elevation
+        required: false
+        schema:
+          type: NUMERIC
+        style: form
+      - explode: false
+        in: query
+        name: manufacturer
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: model
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: serial_number
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: firmware_version
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: control_schedule_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: _version
+        required: false
+        schema:
+          type: INTEGER
+        style: form
+      - explode: false
+        in: query
+        name: _change_date
+        required: false
+        schema:
+          type: TIMESTAMP
+        style: form
+      - explode: false
+        in: query
+        name: _user_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: _status_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: comments
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Features
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Observer items
+      tags:
+      - observer
+  /collections/observer/items/{featureId}:
+    get:
+      description: Data table of observers
+      operationId: getObserverFeature
+      parameters:
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/featureId
+      - $ref: '#/components/parameters/crs'
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Feature
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Observer item by id
+      tags:
+      - observer
+  /collections/observer/queryables:
+    get:
+      description: Data table of observers
+      operationId: getObserverQueryables
+      parameters:
+      - *id001
+      - *id002
+      responses:
+        '200':
+          $ref: '#/components/responses/Queryables'
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Observer queryables
+      tags:
+      - observer
+  /collections/ontario_watershed:
+    get:
+      description: Test / example dataset
+      operationId: describeOntario_watershedCollection
+      parameters:
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Collection
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Example watersheds for Ontario, CA metadata
+      tags:
+      - ontario_watershed
+  /collections/ontario_watershed/items:
+    get:
+      description: Test / example dataset
+      operationId: getOntario_watershedFeatures
+      parameters:
+      - *id001
+      - *id002
+      - $ref: '#/components/parameters/bbox'
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/limit
+      - $ref: '#/components/parameters/crs'
+      - $ref: '#/components/parameters/bbox-crs'
+      - description: The properties that should be included for each feature. The
+          parameter value is a comma-separated list of property names.
+        explode: false
+        in: query
+        name: properties
+        required: false
+        schema:
+          items:
+            enum:
+            - id
+            - name
+            - description
+            - links
+            - feature_type_id
+            - elevation
+            - parent_id
+            - properties
+            - _version
+            - _change_date
+            - _user_id
+            - _status_id
+            - comments
+            type: string
+          type: array
+        style: form
+      - $ref: '#/components/parameters/vendorSpecificParameters'
+      - $ref: '#/components/parameters/skipGeometry'
+      - $ref: https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/parameters/sortby.yaml
+      - $ref: '#/components/parameters/offset'
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/datetime
+      - explode: false
+        in: query
+        name: id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: name
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: description
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: links
+        required: false
+        schema:
+          type: JSONB
+        style: form
+      - explode: false
+        in: query
+        name: feature_type_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: elevation
+        required: false
+        schema:
+          type: NUMERIC
+        style: form
+      - explode: false
+        in: query
+        name: parent_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: properties
+        required: false
+        schema:
+          type: JSONB
+        style: form
+      - explode: false
+        in: query
+        name: _version
+        required: false
+        schema:
+          type: INTEGER
+        style: form
+      - explode: false
+        in: query
+        name: _change_date
+        required: false
+        schema:
+          type: TIMESTAMP
+        style: form
+      - explode: false
+        in: query
+        name: _user_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: _status_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: comments
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Features
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Example watersheds for Ontario, CA items
+      tags:
+      - ontario_watershed
+  /collections/ontario_watershed/items/{featureId}:
+    get:
+      description: Test / example dataset
+      operationId: getOntario_watershedFeature
+      parameters:
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/featureId
+      - $ref: '#/components/parameters/crs'
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Feature
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Example watersheds for Ontario, CA item by id
+      tags:
+      - ontario_watershed
+  /collections/ontario_watershed/queryables:
+    get:
+      description: Test / example dataset
+      operationId: getOntario_watershedQueryables
+      parameters:
+      - *id001
+      - *id002
+      responses:
+        '200':
+          $ref: '#/components/responses/Queryables'
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Example watersheds for Ontario, CA queryables
+      tags:
+      - ontario_watershed
+  /collections/stations:
+    get:
+      description: Extract of hourly observations from the 'Climate Stations' dataset
+        provided by Environment and Climate Change Canada.
+      operationId: describeStationsCollection
+      parameters:
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Collection
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Climate Stations (Ontario, Canada) metadata
+      tags:
+      - stations
+  /collections/stations/items:
+    get:
+      description: Extract of hourly observations from the 'Climate Stations' dataset
+        provided by Environment and Climate Change Canada.
+      operationId: getStationsFeatures
+      parameters:
+      - *id001
+      - *id002
+      - $ref: '#/components/parameters/bbox'
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/limit
+      - $ref: '#/components/parameters/crs'
+      - $ref: '#/components/parameters/bbox-crs'
+      - description: The properties that should be included for each feature. The
+          parameter value is a comma-separated list of property names.
+        explode: false
+        in: query
+        name: properties
+        required: false
+        schema:
+          items:
+            enum:
+            - id
+            - name
+            - description
+            - links
+            - elevation
+            - wigos_station_identifier
+            - facility_type_id
+            - date_established
+            - date_closed
+            - wmo_region_id
+            - territory_id
+            - time_zone_id
+            - valid_from
+            - valid_to
+            - _version
+            - _change_date
+            - _user_id
+            - _status_id
+            - comments
+            type: string
+          type: array
+        style: form
+      - $ref: '#/components/parameters/vendorSpecificParameters'
+      - $ref: '#/components/parameters/skipGeometry'
+      - $ref: https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/parameters/sortby.yaml
+      - $ref: '#/components/parameters/offset'
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/datetime
+      - explode: false
+        in: query
+        name: id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: name
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: description
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: links
+        required: false
+        schema:
+          type: JSONB
+        style: form
+      - explode: false
+        in: query
+        name: elevation
+        required: false
+        schema:
+          type: NUMERIC
+        style: form
+      - explode: false
+        in: query
+        name: wigos_station_identifier
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: facility_type_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: date_established
+        required: false
+        schema:
+          type: TIMESTAMP
+        style: form
+      - explode: false
+        in: query
+        name: date_closed
+        required: false
+        schema:
+          type: TIMESTAMP
+        style: form
+      - explode: false
+        in: query
+        name: wmo_region_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: territory_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: time_zone_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: valid_from
+        required: false
+        schema:
+          type: TIMESTAMP
+        style: form
+      - explode: false
+        in: query
+        name: valid_to
+        required: false
+        schema:
+          type: TIMESTAMP
+        style: form
+      - explode: false
+        in: query
+        name: _version
+        required: false
+        schema:
+          type: INTEGER
+        style: form
+      - explode: false
+        in: query
+        name: _change_date
+        required: false
+        schema:
+          type: TIMESTAMP
+        style: form
+      - explode: false
+        in: query
+        name: _user_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: _status_id
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      - explode: false
+        in: query
+        name: comments
+        required: false
+        schema:
+          type: VARCHAR
+        style: form
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Features
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Climate Stations (Ontario, Canada) items
+      tags:
+      - stations
+    post:
+      description: Extract of hourly observations from the 'Climate Stations' dataset
+        provided by Environment and Climate Change Canada.
+      operationId: addStationsFeatures
+      requestBody:
+        content:
+          application/geo+json:
+            schema: {}
+        description: Adds item to collection
+        required: true
+      responses:
+        '201':
+          description: Successful creation
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Add Climate Stations (Ontario, Canada) items
+      tags:
+      - stations
+  /collections/stations/items/{featureId}:
+    delete:
+      description: Extract of hourly observations from the 'Climate Stations' dataset
+        provided by Environment and Climate Change Canada.
+      operationId: deleteStationsFeatures
+      parameters:
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/featureId
+      responses:
+        '200':
+          description: Successful delete
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Delete Climate Stations (Ontario, Canada) items
+      tags:
+      - stations
+    get:
+      description: Extract of hourly observations from the 'Climate Stations' dataset
+        provided by Environment and Climate Change Canada.
+      operationId: getStationsFeature
+      parameters:
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/featureId
+      - $ref: '#/components/parameters/crs'
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/Feature
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Climate Stations (Ontario, Canada) item by id
+      tags:
+      - stations
+    put:
+      description: Extract of hourly observations from the 'Climate Stations' dataset
+        provided by Environment and Climate Change Canada.
+      operationId: updateStationsFeatures
+      parameters:
+      - $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/featureId
+      requestBody:
+        content:
+          application/geo+json:
+            schema: {}
+        description: Updates item in collection
+        required: true
+      responses:
+        '204':
+          description: Successful update
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Update Climate Stations (Ontario, Canada) items
+      tags:
+      - stations
+  /collections/stations/queryables:
+    get:
+      description: Extract of hourly observations from the 'Climate Stations' dataset
+        provided by Environment and Climate Change Canada.
+      operationId: getStationsQueryables
+      parameters:
+      - *id001
+      - *id002
+      responses:
+        '200':
+          $ref: '#/components/responses/Queryables'
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/NotFound
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: Get Climate Stations (Ontario, Canada) queryables
+      tags:
+      - stations
+  /conformance:
+    get:
+      description: API conformance definition
+      operationId: getConformanceDeclaration
+      parameters:
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/LandingPage
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/ServerError
+      summary: API conformance definition
+      tags:
+      - server
+  /jobs:
+    get:
+      description: Retrieve a list of jobs
+      operationId: getJobs
+      responses:
+        '200':
+          $ref: '#/components/responses/200'
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/responses/NotFound.yaml
+        default:
+          $ref: '#/components/responses/default'
+      summary: Retrieve jobs list
+      tags:
+      - server
+  /jobs/{jobId}:
+    delete:
+      description: Cancel / delete job
+      operationId: deleteJob
+      parameters:
+      - &id003
+        description: job identifier
+        in: path
+        name: jobId
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          $ref: '#/components/responses/204'
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/responses/NotFound.yaml
+        default:
+          $ref: '#/components/responses/default'
+      summary: Cancel / delete job
+      tags:
+      - server
+    get:
+      description: Retrieve job details
+      operationId: getJob
+      parameters:
+      - *id003
+      - $ref: '#/components/parameters/f'
+      responses:
+        '200':
+          $ref: '#/components/responses/200'
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/responses/NotFound.yaml
+        default:
+          $ref: '#/components/responses/default'
+      summary: Retrieve job details
+      tags:
+      - server
+  /jobs/{jobId}/results:
+    get:
+      description: Retrive job resiults
+      operationId: getJobResults
+      parameters:
+      - *id003
+      - $ref: '#/components/parameters/f'
+      responses:
+        '200':
+          $ref: '#/components/responses/200'
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/responses/NotFound.yaml
+        default:
+          $ref: '#/components/responses/default'
+      summary: Retrieve job results
+      tags:
+      - server
+  /openapi:
+    get:
+      description: This document
+      operationId: getOpenapi
+      parameters:
+      - $ref: '#/components/parameters/f'
+      - $ref: '#/components/parameters/lang'
+      - description: UI to render the OpenAPI document
+        explode: false
+        in: query
+        name: ui
+        required: false
+        schema:
+          default: swagger
+          enum:
+          - swagger
+          - redoc
+          type: string
+        style: form
+      responses:
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/responses/InvalidParameter
+        default:
+          $ref: '#/components/responses/default'
+      summary: This document
+      tags:
+      - server
+  /processes:
+    get:
+      description: Processes
+      operationId: getProcesses
+      parameters:
+      - $ref: '#/components/parameters/f'
+      responses:
+        '200':
+          $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/responses/ProcessList.yaml
+        default:
+          $ref: '#/components/responses/default'
+      summary: Processes
+      tags:
+      - server
+  /processes/cdm:
+    get:
+      description: Process to ingest CDM formatted observations
+      operationId: describeCdmProcess
+      parameters:
+      - $ref: '#/components/parameters/f'
+      responses:
+        '200':
+          $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/default'
+      summary: Get process metadata
+      tags:
+      - cdm
+  /processes/cdm/execution:
+    post:
+      description: Process to ingest CDM formatted observations
+      operationId: executeCdmJob
+      requestBody:
+        content:
+          application/json:
+            example:
+              inputs:
+                value: 5
+              outputs:
+                result: 10
+            schema:
+              $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/execute.yaml
+        description: Mandatory execute request JSON
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/200'
+        '201':
+          $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/responses/ExecuteAsync.yaml
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/responses/NotFound.yaml
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/responses/ServerError.yaml
+        default:
+          $ref: '#/components/responses/default'
+      summary: Process import_observations execution
+      tags:
+      - cdm
+  /processes/daycli-encoder:
+    get:
+      description: Process to convert DAYCLI data to BUFR
+      operationId: describeDaycli-encoderProcess
+      parameters:
+      - $ref: '#/components/parameters/f'
+      responses:
+        '200':
+          $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/default'
+      summary: Get process metadata
+      tags:
+      - daycli-encoder
+  /processes/daycli-encoder/execution:
+    post:
+      description: Process to convert DAYCLI data to BUFR
+      operationId: executeDaycli-encoderJob
+      requestBody:
+        content:
+          application/json:
+            example:
+              inputs: {}
+              output:
+                messages: []
+            schema:
+              $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/execute.yaml
+        description: Mandatory execute request JSON
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/200'
+        '201':
+          $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/responses/ExecuteAsync.yaml
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/responses/NotFound.yaml
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/responses/ServerError.yaml
+        default:
+          $ref: '#/components/responses/default'
+      summary: Process daycli-encoder execution
+      tags:
+      - daycli-encoder
+  /processes/ingestHost:
+    get:
+      description: Process to ingest WMDR host / station into CDMS
+      operationId: describeIngesthostProcess
+      parameters:
+      - $ref: '#/components/parameters/f'
+      responses:
+        '200':
+          $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/default'
+      summary: Get process metadata
+      tags:
+      - ingestHost
+  /processes/ingestHost/execution:
+    post:
+      description: Process to ingest WMDR host / station into CDMS
+      operationId: executeIngesthostJob
+      requestBody:
+        content:
+          application/json:
+            example:
+              inputs:
+                WIGOS_identifier: 0-0-0-A1
+              outputs:
+                status: 200
+            schema:
+              $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/execute.yaml
+        description: Mandatory execute request JSON
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/200'
+        '201':
+          $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/responses/ExecuteAsync.yaml
+        '404':
+          $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/responses/NotFound.yaml
+        '500':
+          $ref: https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/responses/ServerError.yaml
+        default:
+          $ref: '#/components/responses/default'
+      summary: Process ingestHost execution
+      tags:
+      - ingestHost
+servers:
+- description: PygeoAPI instance deployed as part of the beta.opencdms.org instance
+  url: http://localhost:5000
+tags:
+- description: PygeoAPI instance deployed as part of the beta.opencdms.org instance
+  externalDocs:
+    description: information
+    url: https://community.wmo.int/activity-areas/wis/wis2-implementation
+  name: server
+- description: SpatioTemporal Asset Catalog
+  name: stac
+- description: Extract of hourly observations from the 'Hourly Climate Observations'
+    dataset provided by Environment and Climate Change Canada.
+  name: observations
+- description: Data table of observers
+  name: observer
+- description: Extract of hourly observations from the 'Climate Stations' dataset
+    provided by Environment and Climate Change Canada.
+  name: stations
+- description: Test / example dataset
+  name: ontario_watershed
+- description: Process to convert DAYCLI data to BUFR
+  name: daycli-encoder
+- description: Process to ingest WMDR host / station into CDMS
+  name: ingestHost
+- description: Process to ingest CDM formatted observations
+  name: cdm
+

--- a/install/containers/pygeoapi/config/pygeoapi-config.yml
+++ b/install/containers/pygeoapi/config/pygeoapi-config.yml
@@ -1,0 +1,800 @@
+server:
+    bind:
+        host: 0.0.0.0
+        port: 5000
+    url: http://localhost:5000
+    mimetype: application/json; charset=UTF-8
+    encoding: utf-8
+    languages:
+        - en-US
+    limit: 500
+    map:
+        url: https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
+        attribution: <a href="https://osm.org/copyright">OpenStreetMap</a> contributors
+    templates:
+        path: /local/app/containers/pygeoapi/templates/
+    manager:
+        name: TinyDB
+        connection: /tmp/pygeoapi-process-manager.db
+        output_dir: /tmp/
+    cors: true
+
+logging:
+    level: DEBUG
+    logfile: /tmp/pygeoapi.log
+
+metadata:
+    identification:
+        title:
+            en: OpenCDMS beta API
+        description:
+            en: |-
+                PygeoAPI instance deployed as part of the beta.opencdms.org instance
+        keywords:
+            en:
+                - wmo
+                - wis 2.0
+        keywords_type: theme
+        terms_of_service: https://public.wmo.int/en/our-mandate/what-we-do/observations/Unified-WMO-Data-Policy-Resolution
+        url: https://community.wmo.int/activity-areas/wis/wis2-implementation
+    license:
+        name: Unified WMO Data Policy
+        url: https://public.wmo.int/en/our-mandate/what-we-do/observations/Unified-WMO-Data-Policy-Resolution
+    provider:
+        name: OpenCDMS
+        url: https://www.opencdms.org
+    contact:
+        name: Lastname, Firstname
+        position: Position Title
+        address: Mailing Address
+        city: City
+        stateorprovince: Administrative Area
+        postalcode: Zip or Postal Code
+        country: Country
+        phone: +xx-xxx-xxx-xxxx
+        fax: +xx-xxx-xxx-xxxx
+        email: you@example.org
+        url: https://example.org
+        hours: Mo-Fr 08:00-17:00
+        instructions: During hours of service. Off on weekends.
+        role: pointOfContact
+
+resources:
+    daycli-encoder:
+      type: process
+      processor:
+          name: csv2bufr.pygeoapi_daycli_plugin.daycliProcessor
+    ingestHost:
+      type: process
+      processor:
+        name: OpenCDMSWMDR.ingestHost
+    cdm:
+      type: process
+      processor:
+          name: cdm.import_observations
+    observations:
+        type: collection
+        title: Hourly climate data from Ontario (ECCC)
+        description: Extract of hourly observations from the 'Hourly Climate Observations' dataset provided by Environment and Climate Change Canada.
+        keywords:
+            - [synop, climate, meteorology, observations, Canada, Ontario]
+        links:
+            - type: text/html
+              rel: canonical
+              title: Hourly Climate Observations
+              href: https://api.weather.gc.ca/collections/climate-hourly
+              hreflang: en-CA
+            - type: text/html
+              rel: license
+              title: Environment and Climate Change Canada Data Servers End-use Licence
+              href: https://eccc-msc.github.io/open-data/licence/readme_en/
+              hreflang: en-CA
+        extents:
+            spatial:
+                bbox: [-142, 42, -52, 84]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            temporal:
+                begin: 1953-01-01T00:00:00Z #TODO
+                end: null # or empty
+        crs:
+            - WGS84
+        providers:
+            - type: feature
+              name: PostgreSQL
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              time_field: phenomenon_end
+              table: observation
+              geom_field: location
+              editable: true
+    observer:
+        type: collection
+        title: Observer
+        description: Data table of observers
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        extents:
+            spatial:
+                bbox: [-142, 42, -52, 84]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            temporal:
+                begin: 1953-01-01T00:00:00Z #TODO
+                end: null # or empty
+        crs:
+            - WGS84
+        providers:
+            - type: feature
+              name: PostgreSQL
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: observer
+              geom_field: location
+    stations:
+        type: collection
+        title: Climate Stations (Ontario, Canada)
+        description: Extract of hourly observations from the 'Climate Stations' dataset provided by Environment and Climate Change Canada.
+        keywords:
+            - [Climate, metadata, stations, host]
+        links:
+            - type: text/html
+              rel: canonical
+              title: Climate Stations
+              href: https://api.weather.gc.ca/collections/climate-stations
+              hreflang: en-CA
+        extents:
+            spatial:
+                bbox: [-142, 42, -52, 84]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            temporal:
+                begin: 1953-01-01T00:00:00Z #TODO
+                end: null # or empty
+        crs:
+            - WGS84
+        providers:
+            - type: feature
+              name: PostgreSQL
+              editable: true
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              geom_field: location
+              title_field: name
+              table: host
+              editable: true
+    ontario_watershed:
+        type: collection
+        title: Example watersheds for Ontario, CA
+        description: Test / example dataset
+        keywords:
+            - [my, climate, data]
+        links:
+            - type: text/html
+              rel: canonical
+              title: Ontario watershed boundaries
+              href: https://geohub.lio.gov.on.ca/maps/mnrf::ontario-watershed-boundaries-owb/about
+              hreflang: en-CA
+        extents:
+            spatial:
+                bbox: [-142, 42, -52, 84]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            temporal:
+                begin: null
+                end: null
+        crs:
+            - WGS84
+        providers:
+            - type: feature
+              name: PostgreSQL
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              table: feature
+              geom_field: geometry
+    observed_property:
+        type: vocabulary
+        title: Observed property
+        description: Observed property code table
+        keywords:
+            - [my, climate, data]
+        links:
+            - type: text/html
+              rel: canonical
+              title: Climate Data Online
+              href: https://climate.weather.gc.ca
+              hreflang: en-CA
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: standard_name
+              table: observed_property
+              geom_field: null
+    observation_type:
+        type: vocabulary
+        title: Observation type
+        description: Observation type code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: observation_type
+    observing_procedure:
+      type: vocabulary
+      title: Observing procedure
+      description: Observing procedure code table
+      keywords:
+        - [ my, climate, data ]
+      links:
+        - type: text/html
+          rel: canonical
+          title: Climate Data Online
+          href: https://climate.weather.gc.ca
+          hreflang: en-CA
+      providers:
+        - type: feature
+          name: PostgreSQL-nonspatial
+          data:
+            host: opencdms-database
+            port: 5432 # Default 5432 if not provided
+            dbname: opencdms
+            user: opencdms
+            password: insecure-change-me
+            search_path: [ cdm,opencdms, public ]
+          id_field: id
+          title_field: name
+          table: observing_procedure
+          geom_field: null
+    climate_zone:
+        type: vocabulary
+        title: Climate zone
+        description: Climate zone code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: climate_zone
+    exposure:
+        type: vocabulary
+        title: Exposure
+        description: Exposure code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: exposure
+    facility_type:
+        type: vocabulary
+        title: Facility type
+        description: Facility Type code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: facility_type
+    feature_type:
+        type: vocabulary
+        title: Feature type
+        description: Feature Type code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: feature_type
+    media_type:
+        type: vocabulary
+        title: Media type
+        description: Media Type code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: media_type
+    observing_method:
+        type: vocabulary
+        title: Observing method
+        description: Observing method code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: observing_method
+    programme:
+        type: vocabulary
+        title: Programme
+        description: Programme code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: programme
+    reference_surface:
+        type: vocabulary
+        title: Reference surface
+        description: Reference surface code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: reference_surface
+    role:
+        type: vocabulary
+        title: Role
+        description: Role code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: role
+    season:
+        type: vocabulary
+        title: Season
+        description: Season code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: season
+    source_type:
+        type: vocabulary
+        title: Source type
+        description: Source type code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: source_type
+    status:
+        type: vocabulary
+        title: Status
+        description: Status code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: status
+    surface_cover:
+        type: vocabulary
+        title: Surface cover
+        description: Surface cover code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: surface_cover
+    surface_roughness:
+        type: vocabulary
+        title: Surface roughness
+        description: Surface roughness code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: surface_roughness
+    territory:
+        type: vocabulary
+        title: Territory
+        description: Territory table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: territory
+    time_zone:
+        type: vocabulary
+        title: Time zone
+        description: time zone code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: time_zone
+    topography:
+        type: vocabulary
+        title: Topography
+        description: Topography code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: topography
+    user:
+        type: vocabulary
+        title: User
+        description: User code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: user
+    wmo_region:
+        type: vocabulary
+        title: WMO Region
+        description: WMO Region code table
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: wmo_region
+    deployment:
+        type: vocabulary
+        title: Deployment
+        description: Data table of deployments
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: deployment
+    observer_characteristics:
+        type: vocabulary
+        title: Observer characteristics
+        description: Data table of observer characteristics
+        keywords:
+            - []
+        links:
+            - type: text/html
+              rel: about
+              title: Example link
+              href: https://example.com
+        providers:
+            - type: feature
+              name: PostgreSQL-nonspatial
+              data:
+                  host: opencdms-database
+                  port: 5432 # Default 5432 if not provided
+                  dbname: opencdms
+                  user: opencdms
+                  password: insecure-change-me
+                  search_path: [cdm,opencdms, public]
+              id_field: id
+              title_field: name
+              table: observer_characteristics

--- a/install/containers/pygeoapi/processes/OpenCDMSWMDR/.gitignore
+++ b/install/containers/pygeoapi/processes/OpenCDMSWMDR/.gitignore
@@ -1,0 +1,42 @@
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+__pycache__
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# local
+.pytest_cache
+
+# pycharm
+.idea

--- a/install/containers/pygeoapi/processes/OpenCDMSWMDR/LICENSE
+++ b/install/containers/pygeoapi/processes/OpenCDMSWMDR/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021-2022, World Meteorological Organization (WMO)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/install/containers/pygeoapi/processes/OpenCDMSWMDR/MANIFEST.in
+++ b/install/containers/pygeoapi/processes/OpenCDMSWMDR/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE README.md requirements.txt
+recursive-include OpenCDMSWMDR *.xslt

--- a/install/containers/pygeoapi/processes/OpenCDMSWMDR/OpenCDMSWMDR/__init__.py
+++ b/install/containers/pygeoapi/processes/OpenCDMSWMDR/OpenCDMSWMDR/__init__.py
@@ -1,0 +1,166 @@
+###############################################################################
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+###############################################################################
+__version__ = "0.0.1"
+
+import json
+import logging
+from pygeoapi.process.base import BaseProcessor, ProcessorExecuteError
+from lxml import etree
+import urllib3
+import os.path
+
+LOGGER = logging.getLogger(__name__)
+
+PROCESS_METADATA = {
+    'version': '0.0.1',
+    'id': 'OpenCDMSWMDR',
+    'title': {
+        'en': 'ingestHost',
+    },
+    'description': {
+        'en': 'Process to ingest WMDR host / station into CDMS',
+    },
+    'keywords': [],
+    'links': [{
+        'type': 'text/html',
+        'rel': 'about',
+        'title': 'information',
+        'href': 'https://example.org/process',
+        'hreflang': 'en-US'
+    }],
+    'inputs': {
+        'WIGOS_identifier': {
+            'title': 'WIGOS Identifier',
+            'description': 'Station to ingest',
+            'schema': {
+                'type': 'string'
+            },
+            'minOccurs': 1,
+            'maxOccurs': 1,
+            'metadata': None,
+            'keywords': []
+        }
+    },
+    'outputs': {
+        'status': {
+            'title': 'Status of request',
+            'schema': {
+                'type': 'numeric'
+            }
+        }
+
+    },
+    'example': {
+        'inputs': {
+            "WIGOS_identifier": "0-0-0-A1"
+        },
+        'outputs':{
+            "status": 200
+        }
+    }
+}
+
+
+THISDIR = os.path.dirname(os.path.realpath(__file__))
+MAPPINGS = f"{THISDIR}{os.sep}transforms"
+
+class ingestHost(BaseProcessor):
+
+    def __init__(self, processor_def):
+        """
+        Initialize object
+        :param processor_def: provider definition
+        :returns: pygeoapi.process.OpenCDMSWMDR.ingestHost
+        """
+
+        super().__init__(processor_def, PROCESS_METADATA)
+
+    def execute(self, data):
+        mimetype = 'application/json'
+        wsi = data.get("WIGOS_identifier", None)
+        if wsi is None:
+            output = {
+                "status": 400,
+                "msg": "Invalid identifier"
+            }
+            return mimetype, output
+
+        http = urllib3.PoolManager()
+
+        # first check if we already have the station
+        api = "http://localhost:5000/collections/stations/items"
+        resp = http.request("GET", f"{api}/{wsi}?f=json")
+        resp = json.loads(resp.data)
+        if resp.get('code', 'recordExists') == 'recordExists':
+            output = {
+                "status": 409,
+                "msg":  "Record with matching identifer already ingested"
+            }
+            return mimetype, output
+
+        # First we need to fetch the metadata record from OSCAR Surface
+        oscar_url = "https://oscar.wmo.int/surface/rest/api"
+        url_ = f"{oscar_url}/wmd/download/{wsi}"
+        resp = http.request("GET", url_)
+        # check status
+        if resp.status != 200:
+            status = resp.status
+            output = {
+                "status": status,
+                "msg": resp.msg
+            }
+            return mimetype, output
+        xml = resp.data
+        xml_root = etree.fromstring(xml)
+        # load transform
+        with open(f"{MAPPINGS}{os.sep}wmdr_to_json.xslt") as fh:
+            xslt = fh.read()
+        xslt_root = etree.fromstring(bytes(xslt,encoding="utf8"))
+        # apply transform
+        transform = etree.XSLT(xslt_root)
+        t = str(transform(xml_root))
+        # replace any empty strings with null
+        t = t.replace('""','null').replace("\n","")
+        # parse to and from JSON, despite being valid json an
+        # exception is raised without doing this
+        obj = json.loads(t)
+        # upload data
+        resp = http.request(
+            "POST",
+            "http://localhost:5000/collections/stations/items",
+            body = json.dumps(obj),
+            headers={
+                "Content-Type": "application/geo+json"
+            }
+        )
+        # return response status
+        output = {
+            "status": resp.status
+        }
+
+        return mimetype, output
+
+    def __repr__(self):
+        return '<ingestHost> {}'.format(self.name)
+
+
+def str_to_geojson():
+    pass

--- a/install/containers/pygeoapi/processes/OpenCDMSWMDR/OpenCDMSWMDR/transforms/wmdr_to_json.xslt
+++ b/install/containers/pygeoapi/processes/OpenCDMSWMDR/OpenCDMSWMDR/transforms/wmdr_to_json.xslt
@@ -1,0 +1,74 @@
+<xsl:stylesheet version="2.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmd="http://www.isotc211.org/2005/gmd"
+    xmlns:wmdr="http://def.wmo.int/wmdr/2017"
+    xmlns:om="http://www.opengis.net/om/2.0"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://def.wmo.int/wmdr/2017 http://schemas.wmo.int/wmdr/1.0RC9/wmdr.xsd">
+    <xsl:output encoding="UTF-8"  omit-xml-declaration="yes"/>
+    <xsl:param name="delim" select="','" />
+    <xsl:param name="quote" select="'&quot;'" />
+    <xsl:param name="break" select="'&#xA;'" />
+    <xsl:param name="host" select="'HOST'" />
+    <xsl:param name="location" select="'LOCATION'" />
+    <xsl:param name="territory" select="'TERRITORY'" />
+    <xsl:param name="programme" select="'PROGRAMME'" />
+    <xsl:param name="observation" select="'OBSERVATION'" />
+    <xsl:param name="version" select="1"/>
+    <xsl:param name="user" select="'tag:beta.opencdms.org,2023:/data/user/default'"/>
+    <xsl:param name="status" select="'tag:beta.opencdms.org,2023:/vocab/status/latest'"/>
+    <xsl:param name="comments" select="'Record extracted from OSCAR/Surface'"/>
+    <xsl:param name="time_zone" select="''"/>
+    <xsl:param name="change_date" select="''"/>
+    <xsl:template match="/">
+        <xsl:param name="wsi" select="/wmdr:WIGOSMetadataRecord/wmdr:facility/wmdr:ObservingFacility/gml:identifier/text()"/>
+        <xsl:param name="id" select="concat('tag:beta.opencdms.org,2023:',$wsi)"/>
+        <xsl:param name="name" select="/wmdr:WIGOSMetadataRecord/wmdr:facility/wmdr:ObservingFacility/gml:name/text()"/>
+        <xsl:param name="description" select="/wmdr:WIGOSMetadataRecord/wmdr:facility/wmdr:ObservingFacility/wmdr:description/wmdr:Description/wmdr:description"/>
+        <xsl:param name="facility_type" select="/wmdr:WIGOSMetadataRecord/wmdr:facility/wmdr:ObservingFacility/wmdr:facilityType/@xlink:href"/>
+        <xsl:param name="date_established" select="/wmdr:WIGOSMetadataRecord/wmdr:facility/wmdr:ObservingFacility/wmdr:dateEstablished"/>
+        <xsl:param name="date_closed" select="/wmdr:WIGOSMetadataRecord/wmdr:facility/wmdr:ObservingFacility/wmdr:dateClosed"/>
+        <xsl:param name="wmo_region" select="/wmdr:WIGOSMetadataRecord/wmdr:facility/wmdr:ObservingFacility/wmdr:wmoRegion/@xlink:href"/>
+        <xsl:param name="territory" select="/wmdr:WIGOSMetadataRecord/wmdr:facility/wmdr:ObservingFacility/wmdr:territory/wmdr:Territory/wmdr:territoryName/@xlink:href"/>
+        <xsl:for-each select="/wmdr:WIGOSMetadataRecord/wmdr:facility/wmdr:ObservingFacility/wmdr:geospatialLocation">
+            <xsl:variable name="pos" select="wmdr:GeospatialLocation/wmdr:geoLocation/gml:Point/gml:pos"/>
+            <xsl:variable name="latitude" select="substring-before($pos,' ')"/>
+            <xsl:variable name="longitude" select="substring-before(substring-after($pos,' '),' ')"/>
+            <xsl:variable name="elevation" select="substring-after(substring-after($pos,' '),' ')"/>
+            <xsl:variable name="valid_from" select="wmdr:GeospatialLocation/wmdr:validPeriod/gml:TimePeriod/gml:beginPosition"/>
+            <xsl:variable name="valid_to" select="wmdr:GeospatialLocation/wmdr:validPeriod/gml:TimePeriod/gml:endPosition"/>
+            <xsl:text>{</xsl:text><xsl:value-of select="$break"/>
+            <xsl:text>    "type": "Feature",</xsl:text><xsl:value-of select="$break"/>
+            <xsl:text>    "properties": {</xsl:text><xsl:value-of select="$break"/>
+            <xsl:text>        "wigos_station_identifier":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$wsi"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "valid_to":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$valid_to"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "facility_type_id":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$facility_type"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "_version":</xsl:text><xsl:value-of select="$version"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "name":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$name"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "date_established":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$date_established"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "_change_date":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$change_date"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "description":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$description"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "date_closed":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$date_closed"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "_user_id":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$user"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "wmo_region_id":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$wmo_region"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "_status_id":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$status"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "territory_id":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$territory"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "comments":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$comments"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "elevation":</xsl:text><xsl:value-of select="$elevation"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "time_zone_id":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$time_zone"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "valid_from":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$valid_from"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "links": [</xsl:text><xsl:value-of select="$break"/>
+            <xsl:text>            {"rel":"canonical", "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/</xsl:text><xsl:value-of select="$wsi"/><xsl:text>", "type": "text/html", "title": "Record for this station on OSCAR/Surface"}</xsl:text><xsl:value-of select="$break"/>
+            <xsl:text>        ]</xsl:text><xsl:value-of select="$break"/>
+            <xsl:text>    }</xsl:text><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>    "id":</xsl:text><xsl:value-of select="$quote"/><xsl:value-of select="$wsi"/><xsl:value-of select="$quote"/><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>    "geometry": {</xsl:text><xsl:value-of select="$break"/>
+            <xsl:text>        "type": "Point"</xsl:text><xsl:value-of select="$delim"/><xsl:value-of select="$break"/>
+            <xsl:text>        "coordinates": [</xsl:text><xsl:value-of select="$longitude"/><xsl:value-of select="$delim"/><xsl:value-of select="$latitude"/><xsl:text>]</xsl:text><xsl:value-of select="$break"/>
+            <xsl:text>    }</xsl:text><xsl:value-of select="$break"/>
+            <xsl:text>}</xsl:text><xsl:value-of select="$break"/>
+        </xsl:for-each>
+    </xsl:template>
+ </xsl:stylesheet>

--- a/install/containers/pygeoapi/processes/OpenCDMSWMDR/README.md
+++ b/install/containers/pygeoapi/processes/OpenCDMSWMDR/README.md
@@ -1,0 +1,3 @@
+# About
+
+cookiecutter git@github.com:david-i-berry/pygeoapi-process-coookiecutter.git

--- a/install/containers/pygeoapi/processes/OpenCDMSWMDR/pyygeoapi-config.yml
+++ b/install/containers/pygeoapi/processes/OpenCDMSWMDR/pyygeoapi-config.yml
@@ -1,0 +1,6 @@
+resources:
+  ingestHost
+    type: process
+    processor:
+      name: OpenCDMSWMDR.ingestHost
+

--- a/install/containers/pygeoapi/processes/OpenCDMSWMDR/requirements.txt
+++ b/install/containers/pygeoapi/processes/OpenCDMSWMDR/requirements.txt
@@ -1,0 +1,1 @@
+pygeoapi

--- a/install/containers/pygeoapi/processes/OpenCDMSWMDR/setup.py
+++ b/install/containers/pygeoapi/processes/OpenCDMSWMDR/setup.py
@@ -1,0 +1,106 @@
+###############################################################################
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+###############################################################################
+
+import io
+import os
+import re
+from setuptools import Command, find_packages, setup
+
+
+class PyTest(Command):
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        import subprocess
+        errno = subprocess.call(['pytest'])
+        raise SystemExit(errno)
+
+
+def read(filename, encoding='utf-8'):
+    """read file contents"""
+    full_path = os.path.join(os.path.dirname(__file__), filename)
+    with io.open(full_path, encoding=encoding) as fh:
+        contents = fh.read().strip()
+    return contents
+
+
+def get_package_version():
+    """get version from top-level package init"""
+    version_file = read('OpenCDMSWMDR/__init__.py')
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+
+KEYWORDS = [
+    
+]
+
+DESCRIPTION = 'Process to ingest WMDR host / station into CDMS'
+
+# ensure a fresh MANIFEST file is generated
+if (os.path.exists('MANIFEST')):
+    os.unlink('MANIFEST')
+
+
+setup(
+    name='OpenCDMSWMDR',
+    version=get_package_version(),
+    description=DESCRIPTION,
+    long_description=read('README.md'),
+    long_description_content_type='text/markdown',
+    license='Apache Software License',
+    platforms='all',
+    keywords=' '.join(KEYWORDS),
+    author='David I. Berry',
+    author_email='dberry@wmo.int',
+    maintainer='David I. Berry',
+    maintainer_email='dberry@wmo.int',
+    url='Package homepage',
+    install_requires=read('requirements.txt').splitlines(),
+    packages=find_packages(),
+    include_package_data=True,
+    entry_points={
+        'console_scripts': [
+            'csv2bufr=csv2bufr.cli:cli'
+        ]
+    },
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: Module',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Topic :: Scientific/Engineering',
+    ],
+    cmdclass={'test': PyTest},
+    test_suite='tests.run_tests'
+)

--- a/install/containers/pygeoapi/processes/cdm/.gitignore
+++ b/install/containers/pygeoapi/processes/cdm/.gitignore
@@ -1,0 +1,42 @@
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+__pycache__
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# local
+.pytest_cache
+
+# pycharm
+.idea

--- a/install/containers/pygeoapi/processes/cdm/LICENSE
+++ b/install/containers/pygeoapi/processes/cdm/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021-2022, World Meteorological Organization (WMO)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/install/containers/pygeoapi/processes/cdm/MANIFEST.in
+++ b/install/containers/pygeoapi/processes/cdm/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE README.md requirements.txt
+recursive-include cdm

--- a/install/containers/pygeoapi/processes/cdm/README.md
+++ b/install/containers/pygeoapi/processes/cdm/README.md
@@ -1,0 +1,3 @@
+# About
+
+cookiecutter git@github.com:david-i-berry/pygeoapi-process-coookiecutter.git

--- a/install/containers/pygeoapi/processes/cdm/cdm/__init__.py
+++ b/install/containers/pygeoapi/processes/cdm/cdm/__init__.py
@@ -1,0 +1,141 @@
+###############################################################################
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+###############################################################################
+__version__ = "0.0.1"
+
+import logging
+from minio import Minio
+import os
+from pygeoapi.process.base import BaseProcessor, ProcessorExecuteError
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from opencdms.adapters import opencdmsdb
+
+LOGGER = logging.getLogger(__name__)
+
+# Get connection details
+UID = os.environ["POSTGRES_USER"]
+PWD = os.environ["POSTGRES_PASSWORD"]
+DBNAME = os.environ["POSTGRES_DB"]
+DBHOST = os.environ["POSTGRES_HOST"]
+DBPORT = os.environ["POSTGRES_PORT"]
+
+PROCESS_METADATA = {
+    'version': '0.0.1',
+    'id': 'cdm',
+    'title': {
+        'en': 'import_observations',
+    },
+    'description': {
+        'en': 'Process to ingest CDM formatted observations',
+    },
+    'keywords': [],
+    'links': [{
+        'type': 'text/html',
+        'rel': 'about',
+        'title': 'information',
+        'href': 'https://example.org/process',
+        'hreflang': 'en-US'
+    }],
+    'inputs': {
+        'example_input': {
+            'title': 'value',
+            'description': 'Number to double',
+            'schema': {
+                'type': 'numeric'
+            },
+            'minOccurs': 1,
+            'maxOccurs': 1,
+            'metadata': None,
+            'keywords': []
+        }
+    },
+    'outputs': { },
+    'example': {
+        'inputs': {
+            "value": 5
+        },
+        'outputs':{
+            "result": 10
+        }
+    }
+}
+
+
+class import_observations(BaseProcessor):
+
+    def __init__(self, processor_def):
+        """
+        Initialize object
+        :param processor_def: provider definition
+        :returns: pygeoapi.process.cdm.import_observations
+        """
+
+        super().__init__(processor_def, PROCESS_METADATA)
+
+    def execute(self, data):
+        mimetype = 'application/json'
+        value = data.get("example_input", None)
+
+        # first get minio connect
+        client = Minio("opencdms-bucket:9000",
+                       access_key="opencdms",
+                       secret_key="insecure-change-me",
+                       secure=False)
+
+        # get names of bucket and data we want to read
+        bucket = data.get("path", None)
+        obj = data.get("object", None)
+        handle = client.get_object(bucket, obj)
+
+        # get other file settings
+        header = data.get("header", 'HEADER')
+        delimiter = data.get("delimiter", '|')
+        null = data.get("null", 'NA')
+        quote = data.get("quote", "E'\b'")
+
+        # now DB connect
+        engine = create_engine(
+            f"postgresql+psycopg2://{UID}:{PWD}@{DBHOST}:{DBPORT}/{DBNAME}",
+            echo=True)
+        # start the mappers
+        try:
+            opencdmsdb.start_mappers()
+        except Exception as e:
+            LOGGER.error(e)
+        # get the session
+        session = sessionmaker(bind=engine)()
+        # now we want to use cursor for bulk upload
+        cursor = session.connection().connection.cursor()
+        with handle as fh:
+            cursor.copy_expert(f"COPY cdm.observation FROM STDIN WITH CSV {header} DELIMITER AS '{delimiter}' NULL AS '{null}' QUOTE {quote}", fh)  # noqa
+        # commit and close session
+        session.commit()
+        session.close()
+
+        output = {
+            "result": "success"
+        }
+        return mimetype, output
+
+
+    def __repr__(self):
+        return '<import_observations> {}'.format(self.name)

--- a/install/containers/pygeoapi/processes/cdm/cookiecutter.json
+++ b/install/containers/pygeoapi/processes/cdm/cookiecutter.json
@@ -1,0 +1,12 @@
+{
+  "author": "Name of author",
+  "email": "Author email address",
+  "maintainer": "Name of maintainer",
+  "maintainer_email": "Maintainer email address",
+  "package_url": "Package homepage",
+  "process_id": "ID for process, imported as import process_id",
+  "process_name": "Name of process class, process_id.process_name",
+  "process_description": "Short description of process",
+  "keywords": [""],
+  "license": ""
+}

--- a/install/containers/pygeoapi/processes/cdm/pyygeoapi-config.yml
+++ b/install/containers/pygeoapi/processes/cdm/pyygeoapi-config.yml
@@ -1,0 +1,6 @@
+resources:
+  import_observations
+    type: process
+    processor:
+      name: cdm.import_observations
+

--- a/install/containers/pygeoapi/processes/cdm/requirements.txt
+++ b/install/containers/pygeoapi/processes/cdm/requirements.txt
@@ -1,0 +1,4 @@
+pygeoapi
+sqlalchemy_utils
+psycopg2
+minio

--- a/install/containers/pygeoapi/processes/cdm/setup.py
+++ b/install/containers/pygeoapi/processes/cdm/setup.py
@@ -1,0 +1,106 @@
+###############################################################################
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+###############################################################################
+
+import io
+import os
+import re
+from setuptools import Command, find_packages, setup
+
+
+class PyTest(Command):
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        import subprocess
+        errno = subprocess.call(['pytest'])
+        raise SystemExit(errno)
+
+
+def read(filename, encoding='utf-8'):
+    """read file contents"""
+    full_path = os.path.join(os.path.dirname(__file__), filename)
+    with io.open(full_path, encoding=encoding) as fh:
+        contents = fh.read().strip()
+    return contents
+
+
+def get_package_version():
+    """get version from top-level package init"""
+    version_file = read('cdm/__init__.py')
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+
+KEYWORDS = [
+    
+]
+
+DESCRIPTION = 'Process to ingest CDM formatted observations'
+
+# ensure a fresh MANIFEST file is generated
+if (os.path.exists('MANIFEST')):
+    os.unlink('MANIFEST')
+
+
+setup(
+    name='cdm',
+    version=get_package_version(),
+    description=DESCRIPTION,
+    long_description=read('README.md'),
+    long_description_content_type='text/markdown',
+    license='Apache Software License',
+    platforms='all',
+    keywords=' '.join(KEYWORDS),
+    author='David I. Berry',
+    author_email='dberry@wmo.int',
+    maintainer='David I. Berry',
+    maintainer_email='dberry@wmo.int',
+    url='cdm',
+    install_requires=read('requirements.txt').splitlines(),
+    packages=find_packages(),
+    include_package_data=True,
+    entry_points={
+        'console_scripts': [
+            'csv2bufr=csv2bufr.cli:cli'
+        ]
+    },
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: Module',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Topic :: Scientific/Engineering',
+    ],
+    cmdclass={'test': PyTest},
+    test_suite='tests.run_tests'
+)

--- a/install/containers/pygeoapi/requirements-providers.txt
+++ b/install/containers/pygeoapi/requirements-providers.txt
@@ -1,0 +1,16 @@
+fiona
+#GDAL>=3.0.0
+netCDF4
+pandas; python_version < '3.7'
+pandas==1.2.5; python_version >= '3.7'
+pygeofilter[backend-sqlalchemy]
+pygeoif==1.0.0
+pygeometa
+scipy
+sodapy
+xarray
+zarr
+flask-cors
+sqlalchemy_utils
+sqlalchemy_json
+jinja2==3.1.2

--- a/install/containers/timescaledb/Dockerfile
+++ b/install/containers/timescaledb/Dockerfile
@@ -1,0 +1,1 @@
+FROM timescale/timescaledb-ha:pg14-latest

--- a/install/default.env
+++ b/install/default.env
@@ -1,0 +1,23 @@
+POSTGRES_USER=opencdms
+POSTGRES_PASSWORD=insecure-change-me
+POSTGRES_DB=opencdms
+POSTGRES_HOST=opencdms-database
+POSTGRES_PORT=5432
+
+PYGEOAPI_CONFIG=/config/pygeoapi-config.yml
+PYGEOAPI_OPENAPI=/config/openapi-config.yml
+
+OPENCDMS_BROKER_QUEUE_MAX=100
+OPENCDMS_BROKER_USERNAME=opencdms
+OPENCDMS_BROKER_PASSWORD=insecure-change-me
+
+# MinIO
+MINIO_ROOT_USER=opencdms
+MINIO_ROOT_PASSWORD=insecure-change-me
+
+# MinIO notifications, note this just sets the end points, the bucket notifications will need to be set on creation
+MINIO_NOTIFY_MQTT_ENABLE_OPENCDMS="on"
+MINIO_NOTIFY_MQTT_BROKER_OPENCDMS="tcp://opencdms-broker:1883"
+MINIO_NOTIFY_MQTT_TOPIC_OPENCDMS="fs"
+MINIO_NOTIFY_MQTT_USERNAME_OPENCDMS="opencdms"
+MINIO_NOTIFY_MQTT_PASSWORD_OPENCDMS="insecure-change-me"

--- a/install/docker-compose.yaml
+++ b/install/docker-compose.yaml
@@ -1,0 +1,91 @@
+version: '3.3'
+# docker-compose file to bring up full stack for OpenCDMS
+# Containers required
+#   - TimescaleDB
+#   - Mosquitto
+#   - MinIO
+#   - pygeoapi
+#   - OpenCDMS-App
+#   - OpenCDMS-Manager
+#   - Scheduler (part of OpenCDMS-Manager?)
+#   - Proxy?
+
+services:
+  database:
+    build:
+      context: .
+      dockerfile: ./containers/timescaledb/Dockerfile
+    container_name: opencdms-database
+    ports:
+      - 5432:5432
+    env_file:
+      - default.env
+    volumes:
+      - postgres:/home/postgres
+
+  broker:
+    container_name: opencdms-broker
+    build:
+      context: ./containers/mosquitto/
+      dockerfile: Dockerfile
+    env_file:
+      - default.env
+    ports:
+      - 1883:1883
+    volumes:
+      - mosquitto:/mosquitto
+
+  bucket:
+    container_name: opencdms-bucket
+    image: minio/minio
+    mem_limit: 512m
+    memswap_limit: 512m
+    restart: always
+    env_file:
+      - default.env
+    command: server --console-address ":9001" /data
+    ports:
+      - 9000:9000
+      - 9001:9001
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 1s
+      retries: 3
+    depends_on:
+      broker:
+        condition: service_started
+
+  api:
+    container_name: opencdms-api
+    build:
+      context: ./containers/pygeoapi/
+      dockerfile: Dockerfile
+    env_file:
+      - default.env
+    ports:
+      - 5000:5000
+    volumes:
+      - "./containers/pygeoapi/config/:/config"
+      - "./:/local/app"
+    tty: true
+    entrypoint: [ "pygeoapi", "serve" ]
+
+  opencdms:
+    container_name: opencdms-manager
+    image: wmoim/dim_eccodes_baseimage:2.28.0
+    volumes:
+      - "./:/local/app"
+    tty: true
+
+#  opencdms-api:
+#  opencdms-ui:
+#  opencdms-manager:
+
+volumes:
+  postgres:
+  mosquitto:
+  minio-data:
+  pygeoapi_config:

--- a/install/init_db.py
+++ b/install/init_db.py
@@ -1,0 +1,87 @@
+import os
+from sqlalchemy import create_engine, text
+from sqlalchemy_utils import database_exists, create_database, drop_database
+from sqlalchemy.orm import sessionmaker
+
+from opencdms.adapters import opencdmsdb
+
+
+# set connection details
+UID = os.environ["POSTGRES_USER"]
+PWD = os.environ["POSTGRES_PASSWORD"]
+DBNAME = os.environ["POSTGRES_DB"]
+DBHOST = os.environ["POSTGRES_HOST"]
+DBPORT = os.environ["POSTGRES_PORT"]
+
+engine = create_engine(f"postgresql+psycopg2://{UID}:{PWD}@{DBHOST}:{DBPORT}/{DBNAME}", echo=True)
+# check whether we want to start clean
+CLEAN = True
+if CLEAN:
+    if database_exists(engine.url):
+        drop_database(engine.url)
+    create_database(engine.url)
+
+with engine.begin() as conn:
+    # Create schema
+    conn.execute(text("CREATE SCHEMA IF NOT EXISTS cdm"))
+    # Add PostGIS extension
+    conn.execute(text("CREATE EXTENSION Postgis;"))
+
+# create tables
+opencdmsdb.mapper_registry.metadata.create_all(engine)
+
+opencdmsdb.start_mappers()
+
+session = sessionmaker(bind=engine)()
+cursor = session.connection().connection.cursor()
+
+code_tables = {
+    "cdm.user": "user.csv",
+    "cdm.status": "status.csv",
+    "cdm.observation_type": "observation_type.csv",
+    "cdm.facility_type": "facility_type.csv",
+    "cdm.feature_type": "feature_type.csv",
+    "cdm.wmo_region": "wmo_region.csv",
+    "cdm.territory": "territory.csv",
+    "cdm.observed_property": "observed_property.csv",
+    "cdm.observing_procedure": "observing_procedure.csv",
+    "cdm.time_zone": "time_zone.csv",
+    "cdm.source_type": "source_type.csv",
+    "cdm.media_type": "media_type.csv",
+    "cdm.climate_zone": "climate_zone.csv",
+    "cdm.surface_cover": "surface_cover.csv",
+    "cdm.surface_roughness": "surface_roughness.csv",
+    "cdm.topography": "topography.csv",
+    "cdm.season": "season.csv",
+    "cdm.programme": "programme.csv",
+    "cdm.observing_method": "observing_method.csv",
+    "cdm.exposure": "exposure.csv",
+    "cdm.reference_surface": "reference_surface.csv",
+    "cdm.role": "role.csv"
+}
+
+# note, order is important
+data_tables = {
+    "cdm.host": ["hosts.csv"],
+    "cdm.source": ["source.csv"],
+    "cdm.observation": ["CA_6016527_1990.csv"],
+    "cdm.feature": ["features.csv"]
+}
+
+for key, value in code_tables.items():
+    print(value)
+    with open(f"/local/app/data/code_tables/{value}") as fh:
+        cursor.copy_expert(f"COPY {key} FROM STDIN WITH CSV HEADER DELIMITER AS '|' NULL AS 'NA' QUOTE E'\b'", fh)
+
+for key, value in data_tables.items():
+    if isinstance(value, list):
+        for item in value:
+            with open(f"/local/app/data/data_tables/{item}") as fh:
+                cursor.copy_expert(f"COPY {key} FROM STDIN WITH CSV HEADER DELIMITER AS '|' NULL AS 'NA' QUOTE E'\b'", fh)
+    else:
+        with open(f"/local/app/data/data_tables/{value}") as fh:
+            cursor.copy_expert(f"COPY {key} FROM STDIN WITH CSV HEADER DELIMITER AS '|' NULL AS 'NA' QUOTE E'\b'", fh)
+
+session.commit()
+session.close()
+

--- a/install/make_bucket.py
+++ b/install/make_bucket.py
@@ -1,0 +1,23 @@
+from minio import Minio
+from minio.notificationconfig import (NotificationConfig, PrefixFilterRule,
+                                      QueueConfig)
+
+client = Minio("opencdms-bucket:9000",
+               access_key="opencdms",
+               secret_key="insecure-change-me",
+               secure=False)
+
+client.make_bucket('incoming')
+
+config = NotificationConfig(
+    queue_config_list=[
+        QueueConfig(
+            "arn:minio:sqs::OPENCDMS:mqtt",
+            ["s3:ObjectCreated:*"],
+            config_id="2",
+            prefix_filter_rule=PrefixFilterRule("CA_")
+        )
+    ],
+)
+
+client.set_bucket_notification("incoming", config)

--- a/install/subscribe.py
+++ b/install/subscribe.py
@@ -1,0 +1,107 @@
+import json
+import logging
+import paho.mqtt.client as mqtt
+import requests
+
+# broker connection details
+broker = "opencdms-broker"
+protocol = "MQTT"
+port = 1883
+uid = "opencdms"
+pwd = "insecure-change-me"
+
+# OGC-API Process endpoint
+API = "http://opencdms-api:5000"
+logging.basicConfig(level=logging.DEBUG)
+LOGGER = logging.getLogger(__name__)
+
+
+def on_connect(client, userdata, flags, rc):
+    LOGGER.debug(f"Connected")
+    for t in userdata['topics']:
+        LOGGER.debug(f"Subscribing to {t}")
+        try:
+            client.subscribe(t)
+            LOGGER.debug(f"Subscribed to {t}")
+        except Exception as e:
+            LOGGER.error(f"Error subscribing to topic {t}")
+            LOGGER.error(e)
+
+
+def on_message(client, userdata, msg):
+    LOGGER.debug("New message received")
+    topic = msg.topic
+    payload = json.loads(msg.payload)
+    LOGGER.debug(json.dumps(payload, indent=4))
+    bucket = None
+    obj = None
+    if topic == 'fs':  # we have minio message
+        LOGGER.debug("fs")
+        # make sure we have Put event
+        if payload['EventName'] == "s3:ObjectCreated:Put":
+            # iterate over records
+            for record in payload['Records']:
+                received = record['eventTime']
+                user = record['userIdentity']
+                bucket = record['s3']['bucket']['name']
+                obj = record['s3']['object']['key']
+        else:
+            LOGGER.warning(f"Unrecognised event {payload['EventName']}, ignored")  # noqa
+
+        if None not in [bucket, obj]:
+            request_inputs = {
+                "mode": "sync",
+                "inputs": {
+                    "path": bucket,
+                    "object": obj,
+                },
+                "outputs": {}
+            }
+            processor = "cdm"
+            request_url = f'{API}/processes/{processor}/execution'
+            # POST request
+            LOGGER.debug(f"{request_url}")
+            LOGGER.debug(f"{request_inputs}")
+            r = requests.post(request_url, json=request_inputs)
+            LOGGER.debug(r.text)
+        else:
+            LOGGER.debug(f"Bucket {bucket} or object {obj} is missing")
+    else:
+        LOGGER.debug(f"Topic {topic} ignored")
+
+
+def load_config():
+    pass
+
+
+'''
+Table to manage processes
+id: autoincrement?
+topic: 
+path/prefix: path in bucket, regex on object
+active: true|false
+processor: name of pygeoapi process
+inputs: json string with inputs to process (in addition to bucket)
+last_run:
+status:
+output_target:
+publish on receipt
+'''
+
+
+def update_scheduler():
+    pass
+
+
+# create new client
+client = mqtt.Client(userdata={'topics': ['fs/#']})
+# set up connection parameters
+client.username_pw_set(uid, pwd)
+# callbacks
+client.on_connect = on_connect
+client.on_message = on_message
+# now connect
+LOGGER.debug("Connecting")
+client.connect(host=broker, port=port)
+LOGGER.debug("Connected")
+client.loop_forever()

--- a/install/wis2-subscribe.py
+++ b/install/wis2-subscribe.py
@@ -1,0 +1,106 @@
+import base64
+from datetime import datetime as dt
+import json
+import os
+import paho.mqtt.client as mqtt
+from pathlib import Path
+import queue
+import requests
+import ssl
+import threading
+import logging
+
+from urllib.parse import urlparse
+
+
+# define queue for storing downloads
+urlQ = queue.Queue()
+
+LOGGER = logging.getLogger(__name__)
+
+# define worker to do the downloads
+def downloadWorker():
+    while True:
+        job = urlQ.get() # get latest job from queue
+        key = job["key"]
+        #filename = job["filename"]
+        url_ = job["url"]
+        # download the data
+        try:
+            r = requests.get(url_, verify=False)
+            LOGGER.error(url_)
+        except Exception as e:
+            LOGGER.error(e)
+        urlQ.task_done()
+
+
+# now MQTT functions etc
+def on_connect(client, userdata, flags, rc):
+    LOGGER.error("connected")
+    # subscribe to default topics
+    for topic in default_topics:
+        LOGGER.error(f"subscribing to {topic}")
+        client.subscribe(topic)
+
+
+def on_message(client, userdata, msg):
+    LOGGER.error("message received")
+    # get time of receipt
+    receipt_time = dt.now().isoformat()
+    # parse message
+    parsed_message = json.loads(msg.payload)
+    topic = msg.topic
+    url_ = None
+    publish_time = parsed_message['properties']['pubtime']
+    observation_time = parsed_message['properties']['datetime']
+    hash = parsed_message['properties']['integrity']['value']
+    hash_method = parsed_message['properties']['integrity']['method']
+    for link in parsed_message['links']:
+        LOGGER.error(link)
+        if (link.get('rel', None) == 'canonical') and (link.get('type', None) == 'application/x-bufr'):
+            url_ = link.get('href', None)
+            LOGGER.error(url_)
+
+    if url_ is not None:
+        job = {
+            'key': hash,
+            'url': url_,
+            'topic': topic,
+            'publish_time': publish_time,
+            'receipt_time': receipt_time,
+            'observation_time': observation_time,
+            'hash': hash,
+            'hash_method': hash_method
+        }
+        LOGGER.error(job)
+        urlQ.put(job)
+
+
+# start worker in the background
+LOGGER.error("Spawning worker")
+threading.Thread(target=downloadWorker, daemon=True).start()
+
+
+LOGGER.error("Loading MQTT config")
+broker = 'globalbroker.meteo.fr'
+port = 443
+pwd = "anonymous"
+uid = "anonymous"
+protocol = "ws"
+#default_topics = ["origin/a/wis2/mwi/#"]
+default_topics = ["origin/a/wis2/swe/#",
+                  "origin/a/wis2/usa/#",
+                  "origin/a/wis2/mwi/#"]
+
+LOGGER.error("Initialising client")
+client = mqtt.Client(transport="websockets")
+client.tls_set(ca_certs=None, certfile=None, keyfile=None,
+               cert_reqs=ssl.CERT_REQUIRED, tls_version=ssl.PROTOCOL_TLS,
+               ciphers=None)
+client.username_pw_set(uid, pwd)
+client.on_connect = on_connect
+client.on_message = on_message
+LOGGER.error("Connecting")
+result = client.connect(host=broker, port=port)
+LOGGER.error("Looping forever")
+client.loop_forever()


### PR DESCRIPTION
I've manually copied all the files from `opencdms-tmp` into `/install` in the main opencdms repo (I couldn't preserve the history from the opencdms-tmp repo because at some point the opencdms-test-data was copied into the repo which made the history very large).

@david-i-berry are you happy using the main opencdms repo from now on?  The `/install` folder is currently identical to the `wis2-sub` branch of your `opencdms-tmp` repo.

If you have local changes to `opencdms-tmp/wis2-sub` that are more recent then feel free to push those to `opencdms-tmp` and we can copy across anything that has changed.