### PR TITLE
Switch to using relative links with pygeoapi

### DIFF
--- a/install/containers/pygeoapi/config/openapi-config.yml
+++ b/install/containers/pygeoapi/config/openapi-config.yml
@@ -1623,7 +1623,7 @@ paths:
       - ingestHost
 servers:
 - description: PygeoAPI instance deployed as part of the beta.opencdms.org instance
-  url: http://localhost:5000
+  url: /
 tags:
 - description: PygeoAPI instance deployed as part of the beta.opencdms.org instance
   externalDocs:

--- a/install/containers/pygeoapi/config/pygeoapi-config.yml
+++ b/install/containers/pygeoapi/config/pygeoapi-config.yml
@@ -2,7 +2,7 @@ server:
     bind:
         host: 0.0.0.0
         port: 5000
-    url: http://localhost:5000
+    url: /
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     languages:


### PR DESCRIPTION
It appears to be possible to use relative links in the pygeoapi web interface by setting `url: /` in config yml files.

The next deployment will test this by pointing both `api.opencdms.org` and `blue.opencdms.org` to the same pygeoapi instance.